### PR TITLE
Add Pokémon thumbnails and Roadmap kanban tab to docs website

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -666,6 +666,8 @@ body::after {
   display: block;
 }
 
+/* roadmap-view has its own display/layout for kanban overflow */
+
 .main-content { display: none; }
 .main-content.active { display: block; }
 
@@ -780,7 +782,7 @@ body::after {
     gap: 16px;
   }
 
-  .main-content, .strategy-view, .about-view, .guide-view {
+  .main-content, .strategy-view, .about-view, .guide-view, .roadmap-view {
     padding: 20px 12px 60px;
   }
 
@@ -1084,6 +1086,54 @@ body::after {
 .rarity-rare      { background: rgba(68, 138, 255, 0.15); color: var(--blue-bright); }
 .rarity-ultrarare { background: rgba(179, 136, 255, 0.15); color: var(--purple-bright); }
 
+/* ---- Pokémon Thumbnails ---- */
+.pokemon-thumb {
+  width: 40px;
+  height: 40px;
+  image-rendering: pixelated;
+  vertical-align: middle;
+  margin-right: 6px;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.6));
+  flex-shrink: 0;
+}
+
+.pokemon-thumb-sm {
+  width: 32px;
+  height: 32px;
+  image-rendering: pixelated;
+  vertical-align: middle;
+  margin-right: 4px;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.6));
+  flex-shrink: 0;
+}
+
+.starter-card .pokemon-sprite-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 80px;
+  margin-bottom: 8px;
+}
+
+.starter-card .pokemon-sprite-wrap img {
+  width: 80px;
+  height: 80px;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 0 10px rgba(0, 200, 83, 0.3));
+}
+
+.party-table .mon-name {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.encounter-table .mon-name {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
 /* ---- Guide Loading State ---- */
 .guide-loading {
   text-align: center;
@@ -1091,6 +1141,192 @@ body::after {
   color: var(--text-muted);
   font-family: var(--font-mono);
 }
+
+/* ============================================================
+   ROADMAP / KANBAN VIEW
+   ============================================================ */
+
+.roadmap-view {
+  display: none;
+  position: relative;
+  z-index: 5;
+  padding: 32px 24px 80px;
+  overflow-x: auto;
+}
+
+.roadmap-view.active {
+  display: block;
+}
+
+.roadmap-loading {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.roadmap-header {
+  margin-bottom: 28px;
+}
+
+.roadmap-header h2 {
+  font-family: var(--font-pixel);
+  font-size: 13px;
+  color: var(--green-bright);
+  text-shadow: 0 0 10px rgba(0, 230, 118, 0.3);
+  margin-bottom: 8px;
+}
+
+.roadmap-header p {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.kanban-board {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  min-width: 860px;
+  align-items: flex-start;
+}
+
+.kanban-column {
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-card);
+}
+
+.kanban-column-header {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--lab-panel-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.kanban-column-title {
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  letter-spacing: 1px;
+  line-height: 1.4;
+}
+
+.kanban-column-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: rgba(255, 255, 255, 0.07);
+  padding: 2px 8px;
+  border-radius: 999px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.kanban-cards {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 640px;
+  overflow-y: auto;
+}
+
+.kanban-card {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-md);
+  padding: 12px 12px 12px 14px;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.kanban-card:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.kanban-card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  gap: 6px;
+}
+
+.kanban-cycle-badge {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.kanban-status-badge {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+
+.kanban-status-completed { background: rgba(0, 230, 118, 0.12); color: var(--green-bright); }
+.kanban-status-failed    { background: rgba(255, 82, 82, 0.12); color: var(--red-bright); }
+.kanban-status-partial   { background: rgba(255, 215, 64, 0.12); color: var(--yellow-bright); }
+.kanban-status-high      { background: rgba(255, 82, 82, 0.12); color: var(--red-bright); }
+.kanban-status-low       { background: rgba(68, 138, 255, 0.12); color: var(--blue-bright); }
+
+.kanban-card-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.kanban-complexity {
+  display: inline-block;
+  margin-top: 8px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* Column colour themes */
+.kanban-column.col-done .kanban-column-header {
+  background: rgba(0, 230, 118, 0.05);
+  border-bottom-color: rgba(0, 230, 118, 0.2);
+}
+.kanban-column.col-done .kanban-column-title { color: var(--green-bright); }
+.kanban-column.col-done .kanban-card { border-left: 3px solid rgba(0, 230, 118, 0.4); }
+
+.kanban-column.col-issues .kanban-column-header {
+  background: rgba(255, 215, 64, 0.05);
+  border-bottom-color: rgba(255, 215, 64, 0.2);
+}
+.kanban-column.col-issues .kanban-column-title { color: var(--yellow-bright); }
+.kanban-column.col-issues .kanban-card { border-left: 3px solid rgba(255, 215, 64, 0.4); }
+
+.kanban-column.col-high .kanban-column-header {
+  background: rgba(255, 82, 82, 0.05);
+  border-bottom-color: rgba(255, 82, 82, 0.2);
+}
+.kanban-column.col-high .kanban-column-title { color: var(--red-bright); }
+.kanban-column.col-high .kanban-card { border-left: 3px solid rgba(255, 82, 82, 0.4); }
+
+.kanban-column.col-planned .kanban-column-header {
+  background: rgba(68, 138, 255, 0.05);
+  border-bottom-color: rgba(68, 138, 255, 0.2);
+}
+.kanban-column.col-planned .kanban-column-title { color: var(--blue-bright); }
+.kanban-column.col-planned .kanban-card { border-left: 3px solid rgba(68, 138, 255, 0.4); }
 
 /* ---- Guide Responsive ---- */
 @media (max-width: 640px) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,6 +34,7 @@
       <button class="active" data-view="journal">Research Logs</button>
       <button data-view="guide">Game Guide</button>
       <button data-view="strategy">Strategy</button>
+      <button data-view="roadmap">Roadmap</button>
       <button data-view="about">About</button>
     </nav>
   </header>
@@ -81,6 +82,13 @@
   <section class="strategy-view">
     <div class="strategy-loading">
       <p>Loading strategy data...</p>
+    </div>
+  </section>
+
+  <!-- View: Roadmap -->
+  <section class="roadmap-view">
+    <div class="roadmap-loading">
+      <p>Loading roadmap data...</p>
     </div>
   </section>
 

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -10,6 +10,131 @@
   let strategyData = null;
   let currentView = 'journal';
 
+  // ---- Pokémon Dex Map (display name → national dex ID) ----
+  // Used to look up sprite URLs from PokéAPI CDN
+  const POKEMON_DEX = {
+    // Gen 1
+    'Bulbasaur':1,'Ivysaur':2,'Venusaur':3,'Charmander':4,'Charmeleon':5,'Charizard':6,
+    'Squirtle':7,'Wartortle':8,'Blastoise':9,'Caterpie':10,'Metapod':11,'Butterfree':12,
+    'Weedle':13,'Kakuna':14,'Beedrill':15,'Pidgey':16,'Pidgeotto':17,'Pidgeot':18,
+    'Rattata':19,'Raticate':20,'Spearow':21,'Fearow':22,'Ekans':23,'Arbok':24,
+    'Pikachu':25,'Raichu':26,'Sandshrew':27,'Sandslash':28,'Nidoran F':29,'Nidorina':30,
+    'Nidoqueen':31,'Nidoran M':32,'Nidorino':33,'Nidoking':34,'Clefairy':35,'Clefable':36,
+    'Vulpix':37,'Ninetales':38,'Jigglypuff':39,'Wigglytuff':40,'Zubat':41,'Golbat':42,
+    'Oddish':43,'Gloom':44,'Vileplume':45,'Paras':46,'Parasect':47,'Venonat':48,
+    'Venomoth':49,'Diglett':50,'Dugtrio':51,'Meowth':52,'Persian':53,'Psyduck':54,
+    'Golduck':55,'Mankey':56,'Primeape':57,'Growlithe':58,'Arcanine':59,'Poliwag':60,
+    'Poliwhirl':61,'Poliwrath':62,'Abra':63,'Kadabra':64,'Alakazam':65,'Machop':66,
+    'Machoke':67,'Machamp':68,'Bellsprout':69,'Weepinbell':70,'Victreebel':71,
+    'Tentacool':72,'Tentacruel':73,'Geodude':74,'Graveler':75,'Golem':76,'Ponyta':77,
+    'Rapidash':78,'Slowpoke':79,'Slowbro':80,'Magnemite':81,'Magneton':82,
+    'Farfetch D':83,'Doduo':84,'Dodrio':85,'Seel':86,'Dewgong':87,'Grimer':88,
+    'Muk':89,'Shellder':90,'Cloyster':91,'Gastly':92,'Haunter':93,'Gengar':94,
+    'Onix':95,'Drowzee':96,'Hypno':97,'Krabby':98,'Kingler':99,'Voltorb':100,
+    'Electrode':101,'Exeggcute':102,'Exeggutor':103,'Cubone':104,'Marowak':105,
+    'Hitmonlee':106,'Hitmonchan':107,'Lickitung':108,'Koffing':109,'Weezing':110,
+    'Rhyhorn':111,'Rhydon':112,'Chansey':113,'Tangela':114,'Kangaskhan':115,
+    'Horsea':116,'Seadra':117,'Goldeen':118,'Seaking':119,'Staryu':120,'Starmie':121,
+    'Mr Mime':122,'Scyther':123,'Jynx':124,'Electabuzz':125,'Magmar':126,'Pinsir':127,
+    'Tauros':128,'Magikarp':129,'Gyarados':130,'Lapras':131,'Ditto':132,'Eevee':133,
+    'Vaporeon':134,'Jolteon':135,'Flareon':136,'Porygon':137,'Omanyte':138,
+    'Omastar':139,'Kabuto':140,'Kabutops':141,'Aerodactyl':142,'Snorlax':143,
+    'Articuno':144,'Zapdos':145,'Moltres':146,'Dratini':147,'Dragonair':148,
+    'Dragonite':149,'Mewtwo':150,'Mew':151,
+    // Gen 2
+    'Chikorita':152,'Bayleef':153,'Meganium':154,'Cyndaquil':155,'Quilava':156,
+    'Typhlosion':157,'Totodile':158,'Croconaw':159,'Feraligatr':160,'Sentret':161,
+    'Furret':162,'Hoothoot':163,'Noctowl':164,'Ledyba':165,'Ledian':166,
+    'Spinarak':167,'Ariados':168,'Crobat':169,'Chinchou':170,'Lanturn':171,
+    'Pichu':172,'Cleffa':173,'Igglybuff':174,'Togepi':175,'Togetic':176,
+    'Natu':177,'Xatu':178,'Mareep':179,'Flaaffy':180,'Ampharos':181,'Bellossom':182,
+    'Marill':183,'Azumarill':184,'Sudowoodo':185,'Politoed':186,'Hoppip':187,
+    'Skiploom':188,'Jumpluff':189,'Aipom':190,'Sunkern':191,'Sunflora':192,
+    'Yanma':193,'Wooper':194,'Quagsire':195,'Espeon':196,'Umbreon':197,
+    'Murkrow':198,'Slowking':199,'Misdreavus':200,'Unown':201,'Wobbuffet':202,
+    'Girafarig':203,'Pineco':204,'Forretress':205,'Dunsparce':206,'Gligar':207,
+    'Steelix':208,'Snubbull':209,'Granbull':210,'Qwilfish':211,'Scizor':212,
+    'Shuckle':213,'Heracross':214,'Sneasel':215,'Teddiursa':216,'Ursaring':217,
+    'Slugma':218,'Magcargo':219,'Swinub':220,'Piloswine':221,'Corsola':222,
+    'Remoraid':223,'Octillery':224,'Delibird':225,'Mantine':226,'Skarmory':227,
+    'Houndour':228,'Houndoom':229,'Kingdra':230,'Phanpy':231,'Donphan':232,
+    'Porygon2':233,'Stantler':234,'Smeargle':235,'Tyrogue':236,'Hitmontop':237,
+    'Smoochum':238,'Elekid':239,'Magby':240,'Miltank':241,'Blissey':242,
+    'Raikou':243,'Entei':244,'Suicune':245,'Larvitar':246,'Pupitar':247,
+    'Tyranitar':248,'Lugia':249,'Ho Oh':250,'Celebi':251,
+    // Gen 3
+    'Treecko':252,'Grovyle':253,'Sceptile':254,'Torchic':255,'Combusken':256,
+    'Blaziken':257,'Mudkip':258,'Marshtomp':259,'Swampert':260,'Poochyena':261,
+    'Mightyena':262,'Zigzagoon':263,'Linoone':264,'Wurmple':265,'Silcoon':266,
+    'Beautifly':267,'Cascoon':268,'Dustox':269,'Lotad':270,'Lombre':271,
+    'Ludicolo':272,'Seedot':273,'Nuzleaf':274,'Shiftry':275,'Taillow':276,
+    'Swellow':277,'Wingull':278,'Pelipper':279,'Ralts':280,'Kirlia':281,
+    'Gardevoir':282,'Surskit':283,'Masquerain':284,'Shroomish':285,'Breloom':286,
+    'Slakoth':287,'Vigoroth':288,'Slaking':289,'Nincada':290,'Ninjask':291,
+    'Shedinja':292,'Whismur':293,'Loudred':294,'Exploud':295,'Makuhita':296,
+    'Hariyama':297,'Azurill':298,'Nosepass':299,'Skitty':300,'Delcatty':301,
+    'Sableye':302,'Mawile':303,'Aron':304,'Lairon':305,'Aggron':306,
+    'Meditite':307,'Medicham':308,'Electrike':309,'Manectric':310,'Plusle':311,
+    'Minun':312,'Volbeat':313,'Illumise':314,'Roselia':315,'Gulpin':316,
+    'Swalot':317,'Carvanha':318,'Sharpedo':319,'Wailmer':320,'Wailord':321,
+    'Numel':322,'Camerupt':323,'Torkoal':324,'Spoink':325,'Grumpig':326,
+    'Spinda':327,'Trapinch':328,'Vibrava':329,'Flygon':330,'Cacnea':331,
+    'Cacturne':332,'Swablu':333,'Altaria':334,'Zangoose':335,'Seviper':336,
+    'Lunatone':337,'Solrock':338,'Barboach':339,'Whiscash':340,'Corphish':341,
+    'Crawdaunt':342,'Baltoy':343,'Claydol':344,'Lileep':345,'Cradily':346,
+    'Anorith':347,'Armaldo':348,'Feebas':349,'Milotic':350,'Castform':351,
+    'Kecleon':352,'Shuppet':353,'Banette':354,'Duskull':355,'Dusclops':356,
+    'Tropius':357,'Chimecho':358,'Absol':359,'Wynaut':360,'Snorunt':361,
+    'Glalie':362,'Spheal':363,'Sealeo':364,'Walrein':365,'Clamperl':366,
+    'Huntail':367,'Gorebyss':368,'Relicanth':369,'Luvdisc':370,'Bagon':371,
+    'Shelgon':372,'Salamence':373,'Beldum':374,'Metang':375,'Metagross':376,
+    'Regirock':377,'Regice':378,'Registeel':379,'Latias':380,'Latios':381,
+    'Kyogre':382,'Groudon':383,'Rayquaza':384,'Jirachi':385,'Deoxys':386,
+    // Gen 4 (may appear as custom additions)
+    'Budew':406,'Roserade':407,'Lucario':448,'Gible':443,'Gabite':444,'Garchomp':445,
+    'Riolu':447,'Mime Jr':439,'Bonsly':438,'Happiny':440,'Togekiss':468,
+    'Magmortar':467,'Electivire':466,'Porygon Z':474,'Glaceon':471,'Leafeon':470,
+    'Weavile':461,'Honchkrow':430,'Mismagius':429,'Ambipom':424,'Dusknoir':477,
+    'Gallade':475,'Froslass':478,'Rotom':479,'Uxie':480,'Mesprit':481,'Azelf':482,
+    'Dialga':483,'Palkia':484,'Heatran':485,'Regigigas':486,'Giratina':487,
+    'Cresselia':488,'Darkrai':491,'Shaymin':492,'Arceus':493,
+  };
+
+  // ---- Pokémon Sprite Helpers ----
+  function pokemonSpriteUrl(name) {
+    const id = POKEMON_DEX[name];
+    if (!id) return null;
+    // Try Gen 3 Emerald sprite first; onerror falls back to modern
+    return 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-iii/emerald/' + id + '.png';
+  }
+
+  function pokemonSpriteFallbackSrc(name) {
+    const id = POKEMON_DEX[name];
+    if (!id) return null;
+    return 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/' + id + '.png';
+  }
+
+  // Creates an <img> element for a Pokémon sprite; returns null if unknown
+  function makeSpriteImg(name, cssClass) {
+    const src = pokemonSpriteUrl(name);
+    if (!src) return null;
+    const img = document.createElement('img');
+    img.src = src;
+    img.alt = name;
+    img.className = cssClass || 'pokemon-thumb';
+    img.loading = 'lazy';
+    const fallback = pokemonSpriteFallbackSrc(name);
+    img.onerror = function () {
+      if (fallback && this.src !== fallback) {
+        this.onerror = function () { this.style.display = 'none'; };
+        this.src = fallback;
+      } else {
+        this.style.display = 'none';
+      }
+    };
+    return img;
+  }
+
   // ---- Bootstrap ----
   document.addEventListener('DOMContentLoaded', () => {
     createParticles();
@@ -158,6 +283,7 @@
     document.querySelector('.main-content').classList.toggle('active', view === 'journal');
     document.querySelector('.guide-view').classList.toggle('active', view === 'guide');
     document.querySelector('.strategy-view').classList.toggle('active', view === 'strategy');
+    document.querySelector('.roadmap-view').classList.toggle('active', view === 'roadmap');
     document.querySelector('.about-view').classList.toggle('active', view === 'about');
   }
 
@@ -183,9 +309,12 @@
       if (!resp.ok) throw new Error('Failed to load strategy data');
       strategyData = await resp.json();
       renderStrategy();
+      renderRoadmap();
     } catch (err) {
       document.querySelector('.strategy-view').innerHTML =
         '<div class="info-card"><p>\u26A0 Unable to load strategy data.</p></div>';
+      document.querySelector('.roadmap-view').innerHTML =
+        '<div class="roadmap-loading"><p>\u26A0 Unable to load roadmap data.</p></div>';
     }
   }
 
@@ -209,20 +338,48 @@
       const starterCard = document.createElement('div');
       starterCard.className = 'info-card';
       const starterEmojis = { 'Rock': '\uD83E\uDEA8', 'Dragon': '\uD83D\uDC09', 'Steel': '\u2699\uFE0F', 'Fire': '\uD83D\uDD25', 'Water': '\uD83D\uDCA7', 'Grass': '\uD83C\uDF3F' };
-      starterCard.innerHTML =
-        '<h3>\u2694\uFE0F New Starter Trio</h3>' +
-        '<div class="starter-grid">' +
-          strategyData.starters.map(function (s) {
-            var primaryType = s.types.split(/\s*[\/→]\s*/)[0].trim();
-            var emoji = starterEmojis[primaryType] || '\uD83D\uDC7E';
-            return '<div class="starter-card">' +
-              '<div class="pokemon-sprite">' + emoji + '</div>' +
-              '<div class="pokemon-name">' + escapeHtml(s.name) + '</div>' +
-              '<div class="pokemon-type">' + escapeHtml(s.types) + '</div>' +
-              '<div class="pokemon-identity" style="font-size:11px;color:var(--text-muted);margin-top:4px">' + escapeHtml(s.identity) + '</div>' +
-            '</div>';
-          }).join('') +
-        '</div>';
+
+      const titleEl = document.createElement('h3');
+      titleEl.textContent = '\u2694\uFE0F New Starter Trio';
+      starterCard.appendChild(titleEl);
+
+      const grid = document.createElement('div');
+      grid.className = 'starter-grid';
+      strategyData.starters.forEach(function (s) {
+        var primaryType = s.types.split(/\s*[\/\u2192]\s*/)[0].trim();
+        var emoji = starterEmojis[primaryType] || '\uD83D\uDC7E';
+        var card = document.createElement('div');
+        card.className = 'starter-card';
+
+        var spriteWrap = document.createElement('div');
+        spriteWrap.className = 'pokemon-sprite-wrap';
+        var img = makeSpriteImg(s.name, null);
+        if (img) {
+          spriteWrap.appendChild(img);
+        } else {
+          spriteWrap.innerHTML = '<span style="font-size:48px">' + emoji + '</span>';
+        }
+        card.appendChild(spriteWrap);
+
+        var nameEl = document.createElement('div');
+        nameEl.className = 'pokemon-name';
+        nameEl.textContent = s.name;
+        card.appendChild(nameEl);
+
+        var typeEl = document.createElement('div');
+        typeEl.className = 'pokemon-type';
+        typeEl.textContent = s.types;
+        card.appendChild(typeEl);
+
+        var identityEl = document.createElement('div');
+        identityEl.className = 'pokemon-identity';
+        identityEl.style.cssText = 'font-size:11px;color:var(--text-muted);margin-top:4px';
+        identityEl.textContent = s.identity;
+        card.appendChild(identityEl);
+
+        grid.appendChild(card);
+      });
+      starterCard.appendChild(grid);
       container.appendChild(starterCard);
     }
 
@@ -286,20 +443,44 @@
     const section = document.createElement('div');
     section.className = 'info-card';
     const typeEmojis = { 'Rock': '\uD83E\uDEA8', 'Dragon': '\uD83D\uDC09', 'Steel': '\u2699\uFE0F', 'Fire': '\uD83D\uDD25', 'Water': '\uD83D\uDCA7', 'Grass': '\uD83C\uDF3F', 'Normal': '\u2B50', 'Psychic': '\uD83D\uDD2E', 'Ground': '\uD83C\uDFDC\uFE0F', 'Ice': '\u2744\uFE0F', 'Electric': '\u26A1' };
-    section.innerHTML =
-      '<h3>\u2694\uFE0F Starter Pok\u00E9mon</h3>' +
-      '<div class="starter-grid">' +
-        guideData.starters.map(s => {
-          const types = s.types || [];
-          const typeStr = types.join(' / ');
-          const emoji = typeEmojis[types[0]] || '\uD83D\uDC7E';
-          return '<div class="starter-card">' +
-            '<div class="pokemon-sprite">' + emoji + '</div>' +
-            '<div class="pokemon-name">' + escapeHtml(s.species) + '</div>' +
-            '<div class="pokemon-type">' + escapeHtml(typeStr) + '</div>' +
-          '</div>';
-        }).join('') +
-      '</div>';
+    const titleEl = document.createElement('h3');
+    titleEl.textContent = '\u2694\uFE0F Starter Pok\u00E9mon';
+    section.appendChild(titleEl);
+
+    const grid = document.createElement('div');
+    grid.className = 'starter-grid';
+
+    guideData.starters.forEach(s => {
+      const types = s.types || [];
+      const typeStr = types.join(' / ');
+      const emoji = typeEmojis[types[0]] || '\uD83D\uDC7E';
+      const card = document.createElement('div');
+      card.className = 'starter-card';
+
+      const spriteWrap = document.createElement('div');
+      spriteWrap.className = 'pokemon-sprite-wrap';
+      const img = makeSpriteImg(s.species, null);
+      if (img) {
+        spriteWrap.appendChild(img);
+      } else {
+        spriteWrap.innerHTML = '<span style="font-size:48px">' + emoji + '</span>';
+      }
+      card.appendChild(spriteWrap);
+
+      const nameEl = document.createElement('div');
+      nameEl.className = 'pokemon-name';
+      nameEl.textContent = s.species;
+      card.appendChild(nameEl);
+
+      const typeEl = document.createElement('div');
+      typeEl.className = 'pokemon-type';
+      typeEl.textContent = typeStr;
+      card.appendChild(typeEl);
+
+      grid.appendChild(card);
+    });
+
+    section.appendChild(grid);
     return section;
   }
 
@@ -410,28 +591,66 @@
     card.className = 'guide-card';
 
     const typeCls = typeClass(opts.typeBadge);
-    card.innerHTML =
-      '<div class="guide-card-header" onclick="toggleGuideCard(this)">' +
-        '<span class="guide-card-title">' + escapeHtml(opts.title) + '</span>' +
-        '<span class="type-badge ' + typeCls + '">' + escapeHtml(opts.typeBadge) + '</span>' +
-        '<span class="card-expand">\u25BC</span>' +
-      '</div>' +
-      (opts.subtitle ? '<div class="guide-card-subtitle">' + escapeHtml(opts.subtitle) + '</div>' : '') +
-      '<div class="guide-card-body">' +
-        '<table class="party-table">' +
-          '<thead><tr><th>Pok\u00E9mon</th><th>Lv</th><th>Held Item</th><th>Moves</th></tr></thead>' +
-          '<tbody>' +
-            opts.party.map(mon =>
-              '<tr>' +
-                '<td class="mon-name">' + escapeHtml(mon.species) + '</td>' +
-                '<td class="mon-level">' + mon.level + '</td>' +
-                '<td>' + (mon.heldItem ? escapeHtml(mon.heldItem) : '\u2014') + '</td>' +
-                '<td class="mon-moves">' + (mon.moves ? mon.moves.map(m => escapeHtml(m)).join(', ') : '<span class="text-muted">Default</span>') + '</td>' +
-              '</tr>'
-            ).join('') +
-          '</tbody>' +
-        '</table>' +
-      '</div>';
+
+    const headerDiv = document.createElement('div');
+    headerDiv.className = 'guide-card-header';
+    headerDiv.setAttribute('onclick', 'toggleGuideCard(this)');
+    headerDiv.innerHTML =
+      '<span class="guide-card-title">' + escapeHtml(opts.title) + '</span>' +
+      '<span class="type-badge ' + typeCls + '">' + escapeHtml(opts.typeBadge) + '</span>' +
+      '<span class="card-expand">\u25BC</span>';
+    card.appendChild(headerDiv);
+
+    if (opts.subtitle) {
+      const sub = document.createElement('div');
+      sub.className = 'guide-card-subtitle';
+      sub.textContent = opts.subtitle;
+      card.appendChild(sub);
+    }
+
+    const bodyDiv = document.createElement('div');
+    bodyDiv.className = 'guide-card-body';
+
+    const table = document.createElement('table');
+    table.className = 'party-table';
+    table.innerHTML = '<thead><tr><th>Pok\u00E9mon</th><th>Lv</th><th>Held Item</th><th>Moves</th></tr></thead>';
+    const tbody = document.createElement('tbody');
+
+    opts.party.forEach(mon => {
+      const tr = document.createElement('tr');
+
+      // Pokémon name cell with sprite
+      const nameTd = document.createElement('td');
+      nameTd.className = 'mon-name';
+      const img = makeSpriteImg(mon.species, 'pokemon-thumb');
+      if (img) nameTd.appendChild(img);
+      nameTd.appendChild(document.createTextNode(mon.species));
+
+      const lvTd = document.createElement('td');
+      lvTd.className = 'mon-level';
+      lvTd.textContent = mon.level;
+
+      const itemTd = document.createElement('td');
+      itemTd.textContent = mon.heldItem || '\u2014';
+
+      const movesTd = document.createElement('td');
+      movesTd.className = 'mon-moves';
+      if (mon.moves && mon.moves.length) {
+        movesTd.textContent = mon.moves.join(', ');
+      } else {
+        movesTd.innerHTML = '<span class="text-muted">Default</span>';
+      }
+
+      tr.appendChild(nameTd);
+      tr.appendChild(lvTd);
+      tr.appendChild(itemTd);
+      tr.appendChild(movesTd);
+      tbody.appendChild(tr);
+    });
+
+    table.appendChild(tbody);
+    bodyDiv.appendChild(table);
+    card.appendChild(bodyDiv);
     return card;
   }
 
@@ -456,23 +675,28 @@
       });
     }
 
-    let bodyHtml = '';
-    if (route.land) bodyHtml += renderEncounterTable('\uD83C\uDF3F Grass / Cave', route.land);
-    if (route.water) bodyHtml += renderEncounterTable('\uD83C\uDF0A Surfing', route.water);
-    if (route.rockSmash) bodyHtml += renderEncounterTable('\uD83E\uDEA8 Rock Smash', route.rockSmash);
+    const headerDiv = document.createElement('div');
+    headerDiv.className = 'guide-card-header';
+    headerDiv.setAttribute('onclick', 'toggleGuideCard(this)');
+    headerDiv.innerHTML =
+      '<span class="guide-card-title">' + escapeHtml(name) + '</span>' +
+      '<span class="encounter-count">' + allSpecies.size + ' species</span>' +
+      '<span class="card-expand">\u25BC</span>';
+    card.appendChild(headerDiv);
+
+    const bodyDiv = document.createElement('div');
+    bodyDiv.className = 'guide-card-body';
+
+    if (route.land) bodyDiv.appendChild(renderEncounterTable('\uD83C\uDF3F Grass / Cave', route.land));
+    if (route.water) bodyDiv.appendChild(renderEncounterTable('\uD83C\uDF0A Surfing', route.water));
+    if (route.rockSmash) bodyDiv.appendChild(renderEncounterTable('\uD83E\uDEA8 Rock Smash', route.rockSmash));
     if (route.fishing) {
-      if (route.fishing.oldRod) bodyHtml += renderEncounterTable('\uD83C\uDFA3 Old Rod', route.fishing.oldRod);
-      if (route.fishing.goodRod) bodyHtml += renderEncounterTable('\uD83C\uDFA3 Good Rod', route.fishing.goodRod);
-      if (route.fishing.superRod) bodyHtml += renderEncounterTable('\uD83C\uDFA3 Super Rod', route.fishing.superRod);
+      if (route.fishing.oldRod) bodyDiv.appendChild(renderEncounterTable('\uD83C\uDFA3 Old Rod', route.fishing.oldRod));
+      if (route.fishing.goodRod) bodyDiv.appendChild(renderEncounterTable('\uD83C\uDFA3 Good Rod', route.fishing.goodRod));
+      if (route.fishing.superRod) bodyDiv.appendChild(renderEncounterTable('\uD83C\uDFA3 Super Rod', route.fishing.superRod));
     }
 
-    card.innerHTML =
-      '<div class="guide-card-header" onclick="toggleGuideCard(this)">' +
-        '<span class="guide-card-title">' + escapeHtml(name) + '</span>' +
-        '<span class="encounter-count">' + allSpecies.size + ' species</span>' +
-        '<span class="card-expand">\u25BC</span>' +
-      '</div>' +
-      '<div class="guide-card-body">' + bodyHtml + '</div>';
+    card.appendChild(bodyDiv);
     return card;
   }
 
@@ -492,22 +716,168 @@
     });
     const deduped = [...seen.values()].sort((a, b) => b.totalRate - a.totalRate);
 
-    return '<div class="encounter-group">' +
-      '<div class="encounter-group-title">' + title + '</div>' +
-      '<table class="encounter-table">' +
-        '<thead><tr><th>Pok\u00E9mon</th><th>Level</th><th>Rate</th><th>Rarity</th></tr></thead>' +
-        '<tbody>' +
-          deduped.map(m =>
-            '<tr>' +
-              '<td class="mon-name">' + escapeHtml(m.species) + '</td>' +
-              '<td>' + (m.minLevel === m.maxLevel ? m.minLevel : m.minLevel + '\u2013' + m.maxLevel) + '</td>' +
-              '<td>' + m.totalRate + '%</td>' +
-              '<td><span class="rarity-badge rarity-' + rarityClass(m.totalRate) + '">' + rarityLabel(m.totalRate) + '</span></td>' +
-            '</tr>'
-          ).join('') +
-        '</tbody>' +
-      '</table>' +
-    '</div>';
+    const group = document.createElement('div');
+    group.className = 'encounter-group';
+
+    const groupTitle = document.createElement('div');
+    groupTitle.className = 'encounter-group-title';
+    groupTitle.innerHTML = title;
+    group.appendChild(groupTitle);
+
+    const table = document.createElement('table');
+    table.className = 'encounter-table';
+    table.innerHTML = '<thead><tr><th>Pok\u00E9mon</th><th>Level</th><th>Rate</th><th>Rarity</th></tr></thead>';
+    const tbody = document.createElement('tbody');
+
+    deduped.forEach(m => {
+      const tr = document.createElement('tr');
+
+      const nameTd = document.createElement('td');
+      nameTd.className = 'mon-name';
+      const img = makeSpriteImg(m.species, 'pokemon-thumb-sm');
+      if (img) nameTd.appendChild(img);
+      nameTd.appendChild(document.createTextNode(m.species));
+
+      const lvTd = document.createElement('td');
+      lvTd.textContent = m.minLevel === m.maxLevel ? m.minLevel : m.minLevel + '\u2013' + m.maxLevel;
+
+      const rateTd = document.createElement('td');
+      rateTd.textContent = m.totalRate + '%';
+
+      const rarityTd = document.createElement('td');
+      rarityTd.innerHTML = '<span class="rarity-badge rarity-' + rarityClass(m.totalRate) + '">' + rarityLabel(m.totalRate) + '</span>';
+
+      tr.appendChild(nameTd);
+      tr.appendChild(lvTd);
+      tr.appendChild(rateTd);
+      tr.appendChild(rarityTd);
+      tbody.appendChild(tr);
+    });
+
+    table.appendChild(tbody);
+    group.appendChild(table);
+    return group; // returns a DOM element
+  }
+
+  // ---- Roadmap / Kanban ----
+
+  function renderRoadmap() {
+    const container = document.querySelector('.roadmap-view');
+    if (!strategyData || !strategyData.roadmap) {
+      container.innerHTML = '<div class="roadmap-loading"><p>\u26A0 No roadmap data available.</p></div>';
+      return;
+    }
+    container.innerHTML = '';
+
+    const header = document.createElement('div');
+    header.className = 'roadmap-header';
+    header.innerHTML =
+      '<h2>\uD83D\uDDFA\uFE0F Implementation Roadmap</h2>' +
+      '<p>Development progress across all cycles \u2014 from completed work to planned objectives.</p>';
+    container.appendChild(header);
+
+    const board = document.createElement('div');
+    board.className = 'kanban-board';
+
+    const { completed = [], upcoming = [] } = strategyData.roadmap;
+
+    // De-duplicate upcoming by (cycle + objective) and split by priority
+    const seenUpcoming = new Set();
+    const highPriority = [];
+    const lowPriority = [];
+    upcoming.forEach(entry => {
+      const key = entry.cycle + '|' + entry.objective;
+      if (seenUpcoming.has(key)) return;
+      seenUpcoming.add(key);
+      if (entry.priority === 'HIGH') {
+        highPriority.push(entry);
+      } else {
+        lowPriority.push(entry);
+      }
+    });
+
+    // Sort high priority by cycle
+    highPriority.sort((a, b) => a.cycle - b.cycle);
+    lowPriority.sort((a, b) => a.cycle - b.cycle);
+
+    const doneItems = completed.filter(c => c.status === 'completed').reverse(); // newest first
+    const issueItems = completed.filter(c => c.status !== 'completed').reverse();
+
+    board.appendChild(buildKanbanColumn('col-done', '\u2705 Completed', doneItems, 'completed'));
+    board.appendChild(buildKanbanColumn('col-issues', '\u26A0\uFE0F Issues', issueItems, 'issues'));
+    board.appendChild(buildKanbanColumn('col-high', '\uD83D\uDD25 Up Next', highPriority, 'upcoming'));
+    board.appendChild(buildKanbanColumn('col-planned', '\uD83D\uDCCB Planned', lowPriority, 'upcoming'));
+
+    container.appendChild(board);
+  }
+
+  function buildKanbanColumn(colClass, title, items, type) {
+    const col = document.createElement('div');
+    col.className = 'kanban-column ' + colClass;
+
+    const header = document.createElement('div');
+    header.className = 'kanban-column-header';
+    header.innerHTML =
+      '<span class="kanban-column-title">' + escapeHtml(title) + '</span>' +
+      '<span class="kanban-column-count">' + items.length + '</span>';
+    col.appendChild(header);
+
+    const cards = document.createElement('div');
+    cards.className = 'kanban-cards';
+
+    if (items.length === 0) {
+      const empty = document.createElement('div');
+      empty.style.cssText = 'padding:16px 12px;font-family:var(--font-mono);font-size:11px;color:var(--text-muted);text-align:center';
+      empty.textContent = 'No items';
+      cards.appendChild(empty);
+    }
+
+    items.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'kanban-card';
+
+      const meta = document.createElement('div');
+      meta.className = 'kanban-card-meta';
+
+      const cycleBadge = document.createElement('span');
+      cycleBadge.className = 'kanban-cycle-badge';
+      cycleBadge.textContent = 'CYCLE ' + String(item.cycle).padStart(2, '0');
+      meta.appendChild(cycleBadge);
+
+      if (type === 'completed' || type === 'issues') {
+        const statusBadge = document.createElement('span');
+        statusBadge.className = 'kanban-status-badge kanban-status-' + (item.status || 'completed');
+        const labels = { completed: '\u2713 Done', failed: '\u2717 Failed', partial: '\u26A0 Partial' };
+        statusBadge.textContent = labels[item.status] || item.status;
+        meta.appendChild(statusBadge);
+      } else {
+        const priorityBadge = document.createElement('span');
+        priorityBadge.className = 'kanban-status-badge kanban-status-' + (item.priority === 'HIGH' ? 'high' : 'low');
+        priorityBadge.textContent = item.priority || 'LOW';
+        meta.appendChild(priorityBadge);
+      }
+
+      card.appendChild(meta);
+
+      const desc = document.createElement('div');
+      desc.className = 'kanban-card-desc';
+      // Strip markdown bold markers for cleaner display
+      const text = (item.description || item.objective || '').replace(/\*\*/g, '');
+      desc.textContent = text;
+      card.appendChild(desc);
+
+      if (type === 'upcoming' && item.complexity) {
+        const complexity = document.createElement('span');
+        complexity.className = 'kanban-complexity';
+        complexity.textContent = item.complexity;
+        card.appendChild(complexity);
+      }
+
+      cards.appendChild(card);
+    });
+
+    col.appendChild(cards);
+    return col;
   }
 
   // ---- Type / Rarity Helpers ----


### PR DESCRIPTION
- Pokémon sprites: full Gen 1–4 dex ID map (386+ entries); sprite images
  loaded from PokéAPI's Gen 3 Emerald CDN with automatic fallback to
  modern sprites, then hidden on second failure
- Thumbnails shown in: starter cards (80px), party tables (40px), and
  wild encounter tables (32px) — all DOM-based so onerror handlers work
- New Roadmap tab: kanban board with 4 colour-coded columns (Completed,
  Issues, Up Next, Planned) built from strategy.json roadmap data;
  deduplicates upcoming items and splits by priority
- Refactored createTrainerCard, createRouteCard, and renderEncounterTable
  to use DOM methods instead of innerHTML strings (needed for img event
  handlers to fire correctly)

https://claude.ai/code/session_01Lqz6Auaj2XbTNfxSSdcq2k