### PR TITLE
Improve journal entry quality: capture reflection narrative, remove noise

### DIFF
--- a/src/agent/output-parser.ts
+++ b/src/agent/output-parser.ts
@@ -15,6 +15,8 @@ export interface ClaudeCodeResult {
   toolCallCount: number;
   /** The text from the final "result" message (e.g. structured JSON from --json-schema) */
   resultText: string;
+  /** Narrative text the agent wrote (pre-CYCLE_COMPLETE); useful as reflection body */
+  narrativeText: string;
 }
 
 export interface ActionRecord {
@@ -35,6 +37,7 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
   let nextSteps = "";
   let toolCallCount = 0;
   let cycleMarkerFound = false;
+  const preMarkerTexts: string[] = [];
   const postMarkerTexts: string[] = [];
   let totalInputTokens = 0;
   let totalOutputTokens = 0;
@@ -96,10 +99,19 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
           } catch {
             // Malformed JSON in marker — ignore
           }
+          // Also capture any text in this block that comes before the marker
+          const beforeMarker = block.text.slice(0, markerMatch.index).trim();
+          if (beforeMarker.length > 50) {
+            preMarkerTexts.push(beforeMarker);
+          }
         } else if (cycleMarkerFound && block.text.trim().length > 50) {
           // Capture substantial text after the CYCLE_COMPLETE marker as
           // fallback summary (e.g. when Oak-voiced text comes in a later turn)
           postMarkerTexts.push(block.text.trim());
+        } else if (!cycleMarkerFound && block.text.trim().length > 50) {
+          // Capture substantial text before the CYCLE_COMPLETE marker as
+          // the narrative reflection body
+          preMarkerTexts.push(block.text.trim());
         }
       }
 
@@ -176,6 +188,11 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
     cycleSummary = postMarkerTexts.reduce((a, b) => (a.length >= b.length ? a : b));
   }
 
+  // Narrative text: the agent's substantive writing before the CYCLE_COMPLETE marker.
+  // Falls back to post-marker text if nothing was written before the marker.
+  const allNarrativeTexts = preMarkerTexts.length > 0 ? preMarkerTexts : postMarkerTexts;
+  const narrativeText = allNarrativeTexts.join("\n\n");
+
   return {
     actions,
     filesModified: [...filesModified],
@@ -189,6 +206,7 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
     },
     toolCallCount,
     resultText,
+    narrativeText,
   };
 }
 

--- a/src/journal/writer.ts
+++ b/src/journal/writer.ts
@@ -83,6 +83,7 @@ ${data.nextSteps || "No next steps specified."}
 
 ## Stats
 
+- Tool calls: ${data.toolCallCount}
 - Tokens used: ${data.tokenUsage.totalTokens.toLocaleString()} (input: ${data.tokenUsage.inputTokens.toLocaleString()}, output: ${data.tokenUsage.outputTokens.toLocaleString()})
 `;
 

--- a/src/reflection/reflect.ts
+++ b/src/reflection/reflect.ts
@@ -39,17 +39,13 @@ export async function runReflection(context: {
     model,
   });
 
-  // Collect the reflection text from actions
-  const reflectionText = [
-    `## Reflection on Cycle ${context.cycleNumber}`,
-    "",
-    `**Summary**: ${result.cycleSummary || context.cycleSummary}`,
-    "",
-    `**Next Steps**: ${result.nextSteps || "Not specified"}`,
-    "",
-    "### Tool calls during reflection:",
-    ...result.actions.map((a) => `- ${a.tool}: ${a.result.slice(0, 100)}`),
-  ].join("\n");
+  // Use the narrative text the reflection agent actually wrote (before its CYCLE_COMPLETE marker).
+  // This captures the substantive "what did I learn / what should I try next" content
+  // rather than duplicating the summary or dumping raw tool call outputs.
+  const narrative = result.narrativeText?.trim() || "";
+  const reflectionText = narrative
+    ? `## Reflection on Cycle ${context.cycleNumber}\n\n${narrative}`
+    : `## Reflection on Cycle ${context.cycleNumber}\n\n*No reflection narrative generated.*`;
 
   logger.info("Reflection phase complete");
 


### PR DESCRIPTION
Three problems with journal entries are fixed:

1. Reflection section was hollow: it duplicated the Summary and Next Steps
   fields verbatim, then dumped raw tool call outputs (file contents, git
   diffs, bash output). The actual narrative the reflection agent wrote was
   silently discarded.

2. output-parser.ts now collects pre-CYCLE_COMPLETE text blocks as
   `narrativeText` — the substantive "what did I learn / what to try next"
   content the agent produces before its completion marker.

3. reflect.ts uses `narrativeText` as the reflection body instead of
   manually assembling duplicate fields + raw tool dumps.

4. writer.ts now renders `toolCallCount` in the Stats section (it was
   tracked but never written to the journal).

https://claude.ai/code/session_01PsKUjrPxD3DD329mAGYPPt