### PR TITLE
Improve release changelog format with structured changes[] field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,10 +85,16 @@ The key is to be **ambitious and intentional**. Each cycle should serve the larg
 When you have finished your work for this cycle, output the following HTML comment marker on its own line:
 
 ```
-<!-- CYCLE_COMPLETE: {"summary": "Brief description of what was accomplished", "next_steps": "What to try in the next cycle"} -->
+<!-- CYCLE_COMPLETE: {"summary": "Oak-voice reflection on the cycle", "changes": ["Player-facing change 1", "Player-facing change 2"], "next_steps": "What to try in the next cycle"} -->
 ```
 
-This marker is parsed by the agent runner to extract your cycle summary and next steps. Always include both `summary` and `next_steps` fields.
+This marker is parsed by the agent runner. Always include all three fields:
+
+| Field | Purpose |
+|---|---|
+| `summary` | Professor Oak narrative reflection (used in journal/release description fallback) |
+| `changes` | Array of short, plain-English player-facing changelog entries (e.g. `"Reduced TM prices from 3,000 to 1,500 Pokédollars"`). These become the bullet points in the GitHub release. Use `[]` if no ROM changes were made. |
+| `next_steps` | Oak-voice description of what to do next cycle |
 
 ## Public Communication
 

--- a/src/agent/output-parser.ts
+++ b/src/agent/output-parser.ts
@@ -10,6 +10,8 @@ export interface ClaudeCodeResult {
   filesModified: string[];
   buildResult: { success: boolean; errors: string[] } | null;
   cycleSummary: string;
+  /** Structured changelog entries for the release (e.g. ["Reduced TM prices", "Added held items"]) */
+  cycleChanges: string[];
   nextSteps: string;
   tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number };
   toolCallCount: number;
@@ -34,6 +36,7 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
   const filesModified = new Set<string>();
   let buildResult: { success: boolean; errors: string[] } | null = null;
   let cycleSummary = "";
+  let cycleChanges: string[] = [];
   let nextSteps = "";
   let toolCallCount = 0;
   let cycleMarkerFound = false;
@@ -92,9 +95,13 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
           try {
             const parsed = JSON.parse(markerMatch[1]) as {
               summary?: string;
+              changes?: string[];
               next_steps?: string;
             };
             cycleSummary = parsed.summary ?? cycleSummary;
+            if (Array.isArray(parsed.changes) && parsed.changes.length > 0) {
+              cycleChanges = parsed.changes.filter((c): c is string => typeof c === "string");
+            }
             nextSteps = parsed.next_steps ?? nextSteps;
           } catch {
             // Malformed JSON in marker — ignore
@@ -198,6 +205,7 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
     filesModified: [...filesModified],
     buildResult,
     cycleSummary,
+    cycleChanges,
     nextSteps,
     tokenUsage: {
       inputTokens: totalInputTokens,

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -283,7 +283,8 @@ Update the memory files in the memory/ directory as needed:
 **IMPORTANT — Reflection completion (follow these steps IN ORDER)**:
 1. First, call the \`/communicate\` skill to write your reflection and next steps in Professor Oak's voice.
 2. Wait for the skill to return the text.
-3. Copy that exact text into the CYCLE_COMPLETE marker:
-   \`<!-- CYCLE_COMPLETE: {"summary": "<paste Oak voice reflection here>", "next_steps": "<paste Oak voice next steps here>"} -->\`
+3. Write a \`changes\` array: a short list of player-facing bullet points (plain English, no jargon) describing what changed this cycle. Each entry should be a single concise sentence, e.g. "Reduced TM prices for combat moves from 3,000 to 1,500 Pokédollars". Aim for 3–6 items. If nothing changed (build failed, no ROM changes), use an empty array.
+4. Output the CYCLE_COMPLETE marker with all fields:
+   \`<!-- CYCLE_COMPLETE: {"summary": "<Oak voice reflection>", "changes": ["<change 1>", "<change 2>"], "next_steps": "<Oak voice next steps>"} -->\`
 Do NOT output the CYCLE_COMPLETE marker at the same time as calling the skill — you must wait for the skill result first.`;
 }

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -322,6 +322,7 @@ async function runReflectionPhase(
     filesModified: implResult.filesModified,
     buildResult,
     cycleSummary: implResult.cycleSummary,
+    cycleChanges: implResult.cycleChanges,
     validationResult,
   });
 }
@@ -551,6 +552,7 @@ export async function runCycle(): Promise<void> {
         commitHash,
         reflection.cycleSummary || "",
         plan.objective,
+        reflection.cycleChanges,
       );
       if (releaseUrl) {
         log.info(`  Release: ${releaseUrl}`);

--- a/src/reflection/reflect.ts
+++ b/src/reflection/reflect.ts
@@ -10,6 +10,8 @@ import type { ValidationResult } from "./validator.js";
 export interface ReflectionResult {
   reflectionText: string;
   cycleSummary: string;
+  /** Structured changelog entries from CYCLE_COMPLETE changes[] field */
+  cycleChanges: string[];
   nextSteps: string;
   actions: ActionRecord[];
   tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number };
@@ -23,6 +25,7 @@ export async function runReflection(context: {
   filesModified: string[];
   buildResult: { success: boolean; errors: string[] } | null;
   cycleSummary: string;
+  cycleChanges: string[];
   validationResult?: ValidationResult | null;
 }): Promise<ReflectionResult> {
   logger.info("Starting reflection phase...");
@@ -52,6 +55,7 @@ export async function runReflection(context: {
   return {
     reflectionText,
     cycleSummary: result.cycleSummary || context.cycleSummary,
+    cycleChanges: result.cycleChanges.length > 0 ? result.cycleChanges : context.cycleChanges,
     nextSteps: result.nextSteps,
     actions: result.actions,
     tokenUsage: result.tokenUsage,

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -35,22 +35,30 @@ function patchFilename(version: GameVersion): string {
 /**
  * Format a player-facing changelog from the cycle summary.
  * Keeps it non-technical and focused on what changed for players.
+ *
+ * If `cycleChanges` is provided, renders them as a bullet list.
+ * Falls back to the narrative `cycleSummary` or `objective` otherwise.
  */
 function formatChangelog(
   version: GameVersion,
   cycleSummary: string,
   objective: string,
+  cycleChanges: string[],
 ): string {
   const date = new Date().toISOString().split("T")[0];
   const versionStr = formatVersion(version);
 
+  const whatsNew =
+    cycleChanges.length > 0
+      ? cycleChanges.map((c) => `- ${c}`).join("\n")
+      : cycleSummary || objective;
+
   return [
-    `## ${versionStr}`,
     `**Released:** ${date}`,
     "",
-    "### What's New",
+    "## What's New",
     "",
-    cycleSummary || objective,
+    whatsNew,
     "",
     "---",
     `*This patch was generated automatically by Agent Oak (cycle ${version.cycle}).*`,
@@ -69,6 +77,7 @@ export async function createCycleRelease(
   commitHash: string,
   cycleSummary: string,
   objective: string,
+  cycleChanges: string[] = [],
 ): Promise<string | null> {
   const octokit = getGitHubClient();
   const repo = getRepoInfo();
@@ -88,7 +97,7 @@ export async function createCycleRelease(
   const tagName = `v${version.major}.${version.minor}.${version.cycle}`;
   const releaseStage = getReleaseStage(version);
   const releaseName = `Agent Oak v${version.major}.${version.minor}.${version.cycle} ${releaseStage} Build ${version.build}`;
-  const changelog = formatChangelog(version, cycleSummary, objective);
+  const changelog = formatChangelog(version, cycleSummary, objective, cycleChanges);
   const assetName = patchFilename(version);
 
   const releaseData = {


### PR DESCRIPTION
Replace the verbose Professor Oak narrative in GitHub release descriptions
with a concise bullet-point changelog. Adds a `changes` array to the
CYCLE_COMPLETE marker that agents populate with short, player-facing
descriptions of what changed each cycle.

- output-parser.ts: extract `changes?: string[]` from CYCLE_COMPLETE JSON
- reflect.ts: thread cycleChanges through ReflectionResult
- release.ts: render changes as bullet list; fall back to narrative if empty
- runner.ts: pass cycleChanges through reflection phase to createCycleRelease
- prompts.ts: instruct reflection agent to populate the changes array
- CLAUDE.md: document the new changes field in CYCLE_COMPLETE

https://claude.ai/code/session_01Van9XbogdTEkv8wzXcjuMo