### PR TITLE
feat: add multi-perspective team planning with parallel advisory agents

### DIFF
--- a/src/cycle/planner.ts
+++ b/src/cycle/planner.ts
@@ -1,9 +1,11 @@
 import { runClaudeCode } from "../agent/claude-cli.js";
+import type { ClaudeCodeResult } from "../agent/output-parser.js";
 import type { CycleMode } from "./modes.js";
 import { CYCLE_MODES } from "./modes.js";
 import { logger } from "../utils/logger.js";
 import { getCycleModeHistorySummary } from "../memory/store.js";
 import type { IssueAction, HelpRequest } from "../github/client.js";
+import { shouldUseTeamPlanning, planCycleWithTeam } from "./team-planner.js";
 
 export interface CyclePlan {
   mode: CycleMode;
@@ -15,7 +17,7 @@ export interface CyclePlan {
 }
 
 /** JSON schema for validated structured output from the planning phase */
-const CYCLE_PLAN_SCHEMA = {
+export const CYCLE_PLAN_SCHEMA: Record<string, unknown> = {
   type: "object",
   properties: {
     mode: {
@@ -74,6 +76,85 @@ const CYCLE_PLAN_SCHEMA = {
   additionalProperties: false,
 };
 
+/**
+ * Parse a ClaudeCodeResult into a CyclePlan.
+ * Shared by both the single planner and team planner (Producer).
+ */
+export function parsePlanResult(result: ClaudeCodeResult): CyclePlan {
+  interface PlanJson {
+    mode?: string;
+    objective?: string;
+    reasoning?: string;
+    implementationPlan?: string;
+    issueActions?: IssueAction[];
+    helpRequests?: HelpRequest[];
+  }
+  let parsed: PlanJson | null = null;
+
+  // Try the resultText first (structured output via --json-schema)
+  if (result.resultText) {
+    try {
+      parsed = JSON.parse(result.resultText) as PlanJson;
+    } catch {
+      // Not valid JSON
+    }
+  }
+
+  // Fallback: look through action results for valid JSON
+  if (!parsed) {
+    for (const action of result.actions) {
+      // Check StructuredOutput tool input directly (contains the plan object)
+      if (action.tool === "StructuredOutput" && action.input) {
+        const candidate = action.input as PlanJson;
+        if (candidate?.mode && candidate?.objective) {
+          parsed = candidate;
+          break;
+        }
+      }
+      if (action.result) {
+        try {
+          const candidate = JSON.parse(action.result) as PlanJson;
+          if (candidate?.mode && candidate?.objective) {
+            parsed = candidate;
+            break;
+          }
+        } catch {
+          // Not JSON, continue
+        }
+      }
+    }
+  }
+
+  // Fallback: try cycleSummary
+  if (!parsed && result.cycleSummary) {
+    try {
+      parsed = JSON.parse(result.cycleSummary) as PlanJson;
+    } catch {
+      // Not JSON
+    }
+  }
+
+  if (parsed?.mode && parsed?.objective && parsed?.reasoning) {
+    const mode = parsed.mode as CycleMode;
+    const issueActions = Array.isArray(parsed.issueActions) ? parsed.issueActions : [];
+    const helpRequests = Array.isArray(parsed.helpRequests) ? parsed.helpRequests : [];
+    if (!CYCLE_MODES[mode]) {
+      logger.warn(`Invalid mode "${parsed.mode}", defaulting to research`);
+      return { mode: "research", objective: parsed.objective, reasoning: parsed.reasoning, implementationPlan: parsed.implementationPlan ?? "", issueActions, helpRequests };
+    }
+    logger.info(`Cycle plan: [${mode}] ${parsed.objective}`);
+    if (issueActions.length > 0) {
+      logger.info(`  Issue actions: ${issueActions.length} (${issueActions.map(a => `#${a.issueNumber}:${a.action}`).join(", ")})`);
+    }
+    if (helpRequests.length > 0) {
+      logger.info(`  Help requests: ${helpRequests.length}`);
+    }
+    return { mode, objective: parsed.objective, reasoning: parsed.reasoning, implementationPlan: parsed.implementationPlan ?? "", issueActions, helpRequests };
+  }
+
+  throw new Error("Could not parse structured plan from CLI output");
+}
+
 /** Use Claude Code CLI to decide what the next cycle should focus on */
 export async function planCycle(
   recentJournalSummaries: string[],
@@ -81,6 +162,13 @@ export async function planCycle(
   issueContext: string = "",
   issueBacklog: string = "",
 ): Promise<CyclePlan> {
+  // Dispatch to team planner if conditions are met
+  if (shouldUseTeamPlanning(cycleNumber, undefined, issueContext.length > 0)) {
+    logger.info("[Planning] Using team planning (multi-perspective advisory)");
+    return planCycleWithTeam(recentJournalSummaries, cycleNumber, issueContext, issueBacklog);
+  }
+
+  logger.info("[Planning] Using single planner");
   const model = process.env.ANTHROPIC_MODEL;
 
   const modeHistorySummary = getCycleModeHistorySummary();
@@ -176,79 +264,7 @@ Respond with a JSON object containing mode, objective, reasoning, implementation
 
     logger.info(`-> Planning result:\n\n\n${JSON.stringify(result, null, 2)}\n\n\n`);
 
-    // With --json-schema, the structured JSON is in the result message's result field
-    interface PlanJson {
-      mode?: string;
-      objective?: string;
-      reasoning?: string;
-      implementationPlan?: string;
-      issueActions?: IssueAction[];
-      helpRequests?: HelpRequest[];
-    }
-    let parsed: PlanJson | null = null;
-
-    // Try the resultText first (structured output via --json-schema)
-    if (result.resultText) {
-      try {
-        parsed = JSON.parse(result.resultText) as PlanJson;
-      } catch {
-        // Not valid JSON
-      }
-    }
-
-    // Fallback: look through action results for valid JSON
-    if (!parsed) {
-      for (const action of result.actions) {
-        // Check StructuredOutput tool input directly (contains the plan object)
-        if (action.tool === "StructuredOutput" && action.input) {
-          const candidate = action.input as PlanJson;
-          if (candidate?.mode && candidate?.objective) {
-            parsed = candidate;
-            break;
-          }
-        }
-        if (action.result) {
-          try {
-            const candidate = JSON.parse(action.result) as PlanJson;
-            if (candidate?.mode && candidate?.objective) {
-              parsed = candidate;
-              break;
-            }
-          } catch {
-            // Not JSON, continue
-          }
-        }
-      }
-    }
-
-    // Fallback: try cycleSummary
-    if (!parsed && result.cycleSummary) {
-      try {
-        parsed = JSON.parse(result.cycleSummary) as PlanJson;
-      } catch {
-        // Not JSON
-      }
-    }
-
-    if (parsed?.mode && parsed?.objective && parsed?.reasoning) {
-      const mode = parsed.mode as CycleMode;
-      const issueActions = Array.isArray(parsed.issueActions) ? parsed.issueActions : [];
-      const helpRequests = Array.isArray(parsed.helpRequests) ? parsed.helpRequests : [];
-      if (!CYCLE_MODES[mode]) {
-        logger.warn(`Invalid mode "${parsed.mode}", defaulting to research`);
-        return { mode: "research", objective: parsed.objective, reasoning: parsed.reasoning, implementationPlan: parsed.implementationPlan ?? "", issueActions, helpRequests };
-      }
-      logger.info(`Cycle plan: [${mode}] ${parsed.objective}`);
-      if (issueActions.length > 0) {
-        logger.info(`  Issue actions: ${issueActions.length} (${issueActions.map(a => `#${a.issueNumber}:${a.action}`).join(", ")})`);
-      }
-      if (helpRequests.length > 0) {
-        logger.info(`  Help requests: ${helpRequests.length}`);
-      }
-      return { mode, objective: parsed.objective, reasoning: parsed.reasoning, implementationPlan: parsed.implementationPlan ?? "", issueActions, helpRequests };
-    }
-
-    throw new Error("Could not parse structured plan from CLI output");
+    return parsePlanResult(result);
   } catch (err) {
     throw new Error(`Planning phase failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
   }

--- a/src/cycle/team-planner.ts
+++ b/src/cycle/team-planner.ts
@@ -1,0 +1,229 @@
+/**
+ * Multi-perspective team planning: runs parallel advisory agents,
+ * then feeds their memos into the existing planner (Producer) for synthesis.
+ */
+
+import { runClaudeCode } from "../agent/claude-cli.js";
+import type { CyclePlan } from "./planner.js";
+import { CYCLE_PLAN_SCHEMA, parsePlanResult } from "./planner.js";
+import { CYCLE_MODES } from "./modes.js";
+import { getCycleModeHistorySummary } from "../memory/store.js";
+import { TEAM_ROLES } from "./team-roles.js";
+import type { TeamRole, TeamContext } from "./team-roles.js";
+import { logger } from "../utils/logger.js";
+
+/** Run a single advisory agent and return its memo text */
+async function runAdvisoryRole(
+  role: TeamRole,
+  ctx: TeamContext,
+): Promise<{ name: string; label: string; memo: string }> {
+  const prompt = role.buildPrompt(ctx);
+  try {
+    logger.info(`  [Team] Running ${role.label} advisor...`);
+    const result = await runClaudeCode(prompt, {
+      maxTurns: role.maxTurns,
+      timeout: role.timeout,
+      tools: role.tools,
+      model: process.env.ANTHROPIC_MODEL,
+    });
+    const memo = result.narrativeText || result.resultText || "(no memo produced)";
+    logger.info(`  [Team] ${role.label} memo: ${memo.length} chars`);
+    return { name: role.name, label: role.label, memo };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    logger.warn(`  [Team] ${role.label} advisor failed: ${errMsg}`);
+    return {
+      name: role.name,
+      label: role.label,
+      memo: `(The ${role.label} was unavailable for this session.)`,
+    };
+  }
+}
+
+/** Build the advisory memo section injected into the Producer prompt */
+function buildMemoSection(
+  memos: Array<{ name: string; label: string; memo: string }>,
+): string {
+  const successfulMemos = memos.filter(
+    (m) => !m.memo.startsWith("(The "),
+  );
+  if (successfulMemos.length === 0) return "";
+
+  const parts = memos.map(
+    (m) => `### ${m.label}\n${m.memo}`,
+  );
+
+  return `\n\n## Advisory Team Memos
+
+Before making your decision, consider these perspectives from your advisory team. You may agree or disagree with any advisor — the final decision is yours. In your \`reasoning\` field, briefly note which perspectives influenced your decision.
+
+${parts.join("\n\n")}`;
+}
+
+/**
+ * Plan the next cycle using parallel advisory agents + a synthesis producer.
+ *
+ * 1. Build shared context from journal, mode history, issues
+ * 2. Run 3 advisory roles in parallel (game designer, tech lead, QA lead)
+ * 3. Inject their memos into the existing planner prompt
+ * 4. Run the Producer with --json-schema to get a CyclePlan
+ */
+export async function planCycleWithTeam(
+  recentJournalSummaries: string[],
+  cycleNumber: number,
+  issueContext: string = "",
+  issueBacklog: string = "",
+): Promise<CyclePlan> {
+  const model = process.env.ANTHROPIC_MODEL;
+
+  // Build shared context (same as planner.ts)
+  const modeHistorySummary = getCycleModeHistorySummary();
+  const journalContext =
+    recentJournalSummaries.length > 0
+      ? recentJournalSummaries.join("\n\n---\n\n")
+      : "No previous cycles. This is the very first cycle.";
+
+  const modeList = Object.values(CYCLE_MODES)
+    .map((m) => `- **${m.name}**: ${m.description}`)
+    .join("\n");
+
+  const issueSection = issueContext ? `\n\n${issueContext}\n` : "";
+  const backlogSection = issueBacklog
+    ? `\n\n## Deferred Issue Backlog\n\nThe following issues were deferred from earlier cycles. You may pick one up this cycle if the timing is right — include it in \`issueActions\` with action "accept" along with a brief response.\n\n${issueBacklog}\n`
+    : "";
+
+  const teamCtx: TeamContext = {
+    cycleNumber,
+    journalContext,
+    modeHistorySummary,
+    modeList,
+    issueSection,
+    backlogSection,
+  };
+
+  // Phase A: Run advisory roles in parallel
+  logger.info(`[Team Planning] Running ${TEAM_ROLES.length} advisory agents in parallel...`);
+  const memos = await Promise.all(
+    TEAM_ROLES.map((role) => runAdvisoryRole(role, teamCtx)),
+  );
+
+  const successCount = memos.filter((m) => !m.memo.startsWith("(The ")).length;
+  logger.info(`[Team Planning] ${successCount}/${TEAM_ROLES.length} advisors produced memos`);
+
+  // If ALL advisors failed, fall back to single-planner (imported dynamically to avoid circular dep)
+  if (successCount === 0) {
+    logger.warn("[Team Planning] All advisors failed — falling back to single planner");
+    // Dynamic import to avoid circular dependency with planner.ts
+    const { planCycle } = await import("./planner.js");
+    return planCycle(recentJournalSummaries, cycleNumber, issueContext, issueBacklog);
+  }
+
+  // Phase B: Build Producer prompt (existing planner prompt + memos)
+  const memoSection = buildMemoSection(memos);
+
+  const prompt = `You are Agent Oak's planning module (the **Producer**). Decide what the next autonomous cycle should focus on.
+
+Your advisory team has provided their perspectives below. Consider all viewpoints, but the final decision is yours — you may disagree with any advisor. In your \`reasoning\` field, note which perspectives influenced your decision.
+
+Cycle ${cycleNumber} is about to start.
+
+## Last Cycle's Journal
+${journalContext}
+
+## Cycle Mode History
+Use this summary of past cycle modes to inform your decision, but do not feel constrained by it.
+If the previous few cycles were all "research", maybe it's time for a "feature". If there was a recent "repair", maybe a "patch" or "refactor" is next.
+Use your judgment to choose the best mode for the current situation and objective — the goal is to build a great ROM hack, not to follow a rigid pattern.
+
+${modeHistorySummary}
+
+
+## Memory Files (on demand)
+
+Your full memory is in the \`memory/\` directory. Read these files if you need more context before deciding — don't pre-emptively read them all, only fetch what is relevant:
+
+- \`memory/strategy-notes.md\` — game design direction, multi-cycle roadmap, and goals
+- \`memory/codebase-facts.md\` — discovered facts about the pokeemerald codebase
+- \`memory/failure-patterns.md\` — build failures encountered and their solutions
+- \`memory/project-facts.md\` — build system details and configuration notes
+
+You can also read specific cycle journals in \`memory/cycles/cycle-<n>.md\` for more details on past cycles if needed.
+
+## Available Modes
+${modeList}
+${issueSection}${backlogSection}${memoSection}
+
+Decide: What mode should this cycle use, and what should the objective be?
+
+If previous cycles had build failures, consider "repair".
+
+
+Once you have decided on the objective, write a precise \`implementationPlan\` field. The implementation agent runs on a less capable model — it should execute your plan, not make design decisions. Your instructions must be complete and specific:
+
+**General structure**:
+1. What to read or understand first
+2. Logical actions to take in order
+3. Conventions or patterns to follow
+4. How to verify the work compiled and is correct
+
+**CRITICAL — Specifying creative content**:
+When the plan involves game content (dialogue, encounter tables, trainer rosters, item placements, stat values, move sets, evolution changes, etc.), you MUST provide the complete, verbatim content in the plan itself. The implementation agent should NOT be inventing dialogue, choosing Pokémon species, deciding stat values, or making any creative choices.
+
+**What to specify completely (not exhaustive - use your own judgment)**:
+- Full dialogue text (exact wording)
+- Complete encounter tables (species, levels, encounter rates)
+- Exact trainer rosters (species, levels, held items, moves)
+- Specific numerical values (stats, experience yields, catch rates)
+- Item lists and placement locations
+- Evolution conditions and methods
+
+The implementation agent's job is to locate the right files and make the necessary changes — not to design the content itself. When in doubt, over-specify.
+
+If there are community issues listed above, review each one and include your decisions in the \`issueActions\` array. You have full freedom to accept, defer, reject, or ask for more info. If an accepted issue should shape this cycle's objective, incorporate it.
+
+**Important**: When writing issue responses, adopt Professor Oak's warm, encouraging voice — treat contributors like promising young trainers. Be kind, curious, and use gentle Pokémon metaphors. See the /communicate skill for voice examples, though you cannot invoke it during structured output.
+
+You may also include \`helpRequests\` if you are stuck on something and want to ask the community for help.
+
+Respond with a JSON object containing mode, objective, reasoning, implementationPlan, and optionally issueActions and helpRequests.`;
+
+  logger.info(`[Team Planning] Running Producer (synthesis) with advisory memos...`);
+  logger.info(`-> Producer prompt:\n\n\n${prompt}\n\n\n`);
+
+  const result = await runClaudeCode(prompt, {
+    maxTurns: 10,
+    timeout: 5 * 60 * 1000,
+    model,
+    jsonSchema: CYCLE_PLAN_SCHEMA,
+  });
+
+  logger.info(`-> Producer result:\n\n\n${JSON.stringify(result, null, 2)}\n\n\n`);
+
+  return parsePlanResult(result);
+}
+
+/**
+ * Determine whether team planning should be used for this cycle.
+ *
+ * Controlled by env var AGENT_TEAM_PLANNING=auto|always|never (default: auto).
+ */
+export function shouldUseTeamPlanning(
+  cycleNumber: number,
+  lastCycleMode?: string,
+  hasIssues: boolean = false,
+): boolean {
+  const setting = (process.env.AGENT_TEAM_PLANNING ?? "auto").toLowerCase();
+
+  if (setting === "never") return false;
+  if (setting === "always") return true;
+
+  // Auto logic:
+  // - Skip if last cycle was repair (answer is obvious — fix the build)
+  if (lastCycleMode === "repair") return false;
+  // - Skip early cycles (not enough history for advisors to add value)
+  if (cycleNumber < 3) return false;
+  // - Use teams when community issues are present (multiple perspectives help)
+  if (hasIssues) return true;
+  // - Default: use team planning for mature projects
+  return true;
+}

--- a/src/cycle/team-roles.ts
+++ b/src/cycle/team-roles.ts
@@ -1,0 +1,159 @@
+/**
+ * Advisory team roles for multi-perspective cycle planning.
+ *
+ * Each role produces a short text memo that gets injected into the
+ * Producer (synthesis) prompt, giving the planner diverse viewpoints
+ * before it makes the final CyclePlan decision.
+ */
+
+export interface TeamContext {
+  cycleNumber: number;
+  journalContext: string;
+  modeHistorySummary: string;
+  modeList: string;
+  issueSection: string;
+  backlogSection: string;
+}
+
+export interface TeamRole {
+  /** Machine name, e.g. "game-designer" */
+  name: string;
+  /** Human-readable label, e.g. "Game Designer" */
+  label: string;
+  /** Max agentic turns for this advisory call */
+  maxTurns: number;
+  /** Timeout in milliseconds */
+  timeout: number;
+  /** Comma-separated tool list (advisors are read-only) */
+  tools: string;
+  /** Build the full prompt for this advisor given shared context */
+  buildPrompt: (ctx: TeamContext) => string;
+}
+
+const gameDesignerRole: TeamRole = {
+  name: "game-designer",
+  label: "Game Designer",
+  maxTurns: 5,
+  timeout: 2 * 60 * 1000,
+  tools: "Read",
+  buildPrompt: (ctx) => `You are the **Game Designer** advisor on a Pokémon Emerald ROM hack project called Agent Oak.
+
+Your job: write a short advisory memo (200-400 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+
+## What you care about
+- Player experience, fun factor, and engagement
+- Difficulty curve and pacing across the game
+- Content gaps — what areas of the game feel underdeveloped?
+- Theme and creative identity — what makes this hack worth playing?
+- Whether the current roadmap serves the overall vision
+
+## Context
+
+### Last Cycle Journal
+${ctx.journalContext}
+
+### Cycle Mode History
+${ctx.modeHistorySummary}
+
+### Available Modes
+${ctx.modeList}
+${ctx.issueSection}${ctx.backlogSection}
+
+## Your Memory
+Read \`memory/strategy-notes.md\` — it contains the game design direction, multi-cycle roadmap, and goals.
+
+## Instructions
+1. Read \`memory/strategy-notes.md\` to understand the current creative vision.
+2. Consider: What should the next cycle focus on from a **player experience** perspective?
+3. Write a plain-text memo addressed to "Producer" with your recommendation.
+4. Be opinionated — rank your top 1-2 priorities and explain why they matter for the player.
+5. If community issues are listed above, note which ones excite you from a design perspective.
+6. Do NOT produce JSON. Just write your memo as plain text.`,
+};
+
+const techLeadRole: TeamRole = {
+  name: "tech-lead",
+  label: "Technical Lead",
+  maxTurns: 5,
+  timeout: 2 * 60 * 1000,
+  tools: "Read",
+  buildPrompt: (ctx) => `You are the **Technical Lead** advisor on a Pokémon Emerald ROM hack project called Agent Oak.
+
+Your job: write a short advisory memo (200-400 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+
+## What you care about
+- Feasibility — can the implementation agent actually do this in one cycle?
+- Build risk — will this change break the ROM compilation?
+- Code complexity — how many files need to change? Are there tricky dependencies?
+- Known failure patterns — have we tried something similar before and failed?
+- Technical debt — should we stabilize before adding features?
+
+## Context
+
+### Last Cycle Journal
+${ctx.journalContext}
+
+### Cycle Mode History
+${ctx.modeHistorySummary}
+
+### Available Modes
+${ctx.modeList}
+${ctx.issueSection}${ctx.backlogSection}
+
+## Your Memory
+Read \`memory/failure-patterns.md\` and \`memory/codebase-facts.md\` — they contain known build issues and codebase knowledge.
+
+## Instructions
+1. Read \`memory/failure-patterns.md\` and \`memory/codebase-facts.md\`.
+2. Consider: What is technically feasible and what is risky for the next cycle?
+3. Write a plain-text memo addressed to "Producer" with your assessment.
+4. Flag any specific risks or prerequisites. If a recent cycle failed, note whether repair should take priority.
+5. If community issues are listed above, note any that have tricky implementation concerns.
+6. Do NOT produce JSON. Just write your memo as plain text.`,
+};
+
+const qaLeadRole: TeamRole = {
+  name: "qa-lead",
+  label: "QA Lead",
+  maxTurns: 3,
+  timeout: 90 * 1000,
+  tools: "Read",
+  buildPrompt: (ctx) => `You are the **QA Lead** advisor on a Pokémon Emerald ROM hack project called Agent Oak.
+
+Your job: write a short advisory memo (150-300 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+
+## What you care about
+- Current build health — is the ROM compiling successfully?
+- Regression risks — will proposed changes break existing work?
+- Validation gaps — are there changes from recent cycles that haven't been verified?
+- Stability vs. features — should we stabilize before pushing forward?
+
+## Context
+
+### Last Cycle Journal
+${ctx.journalContext}
+
+### Cycle Mode History
+${ctx.modeHistorySummary}
+
+### Available Modes
+${ctx.modeList}
+
+## Your Memory
+Read \`memory/failure-patterns.md\` — it tracks build failures and their solutions.
+
+## Instructions
+1. Read \`memory/failure-patterns.md\`.
+2. Consider: Is the project in a healthy state? Are there unresolved issues that need attention?
+3. Write a plain-text memo addressed to "Producer" with your quality assessment.
+4. If the last cycle had build failures, strongly recommend repair mode.
+5. Be concise and direct. Flag blockers clearly.
+6. Do NOT produce JSON. Just write your memo as plain text.`,
+};
+
+/** All advisory roles that run in parallel before the Producer */
+export const TEAM_ROLES: TeamRole[] = [
+  gameDesignerRole,
+  techLeadRole,
+  qaLeadRole,
+];


### PR DESCRIPTION
Introduces a "team planning" mode where three advisory agents (Game Designer,
Technical Lead, QA Lead) run in parallel, each producing a short memo from
their perspective. These memos are injected into the Producer (synthesis)
prompt, giving the planner diverse viewpoints before making the final
CyclePlan decision.

- New: src/cycle/team-roles.ts — role definitions with prompt builders
- New: src/cycle/team-planner.ts — parallel orchestration + shouldUseTeamPlanning()
- Modified: src/cycle/planner.ts — exported CYCLE_PLAN_SCHEMA, extracted
  parsePlanResult(), added team planning dispatch at top of planCycle()

Controlled by AGENT_TEAM_PLANNING=auto|always|never (default: auto).
Auto mode uses team planning for cycles >= 3 unless last cycle was repair.
Gracefully degrades to single planner if all advisors fail.

https://claude.ai/code/session_01LbzfNCuu95Mo7ZufDQgWGN