### PR TITLE
feat: replace QA Lead with Creative Visionary on advisory panel

### DIFF
--- a/src/cycle/team-roles.ts
+++ b/src/cycle/team-roles.ts
@@ -112,21 +112,22 @@ Read \`memory/failure-patterns.md\` and \`memory/codebase-facts.md\` — they co
 6. Do NOT produce JSON. Just write your memo as plain text.`,
 };
 
-const qaLeadRole: TeamRole = {
-  name: "qa-lead",
-  label: "QA Lead",
-  maxTurns: 3,
+const creativeVisionaryRole: TeamRole = {
+  name: "creative-visionary",
+  label: "Creative Visionary",
+  maxTurns: 4,
   timeout: 90 * 1000,
   tools: "Read",
-  buildPrompt: (ctx) => `You are the **QA Lead** advisor on a Pokémon Emerald ROM hack project called Agent Oak.
+  buildPrompt: (ctx) => `You are the **Creative Visionary** advisor on a Pokémon Emerald ROM hack project called Agent Oak.
 
-Your job: write a short advisory memo (150-300 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+Your job: write a punchy advisory memo (200-350 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
 
 ## What you care about
-- Current build health — is the ROM compiling successfully?
-- Regression risks — will proposed changes break existing work?
-- Validation gaps — are there changes from recent cycles that haven't been verified?
-- Stability vs. features — should we stabilize before pushing forward?
+- What would make this hack *genuinely memorable* — not just competent, but worth talking about?
+- Which bold ideas have been deferred too long?
+- When is "playing it safe" actually a missed opportunity to create something special?
+- What is the most ambitious version of what we could do this cycle?
+- Pushing beyond incremental improvements toward transformative changes
 
 ## Context
 
@@ -138,16 +139,17 @@ ${ctx.modeHistorySummary}
 
 ### Available Modes
 ${ctx.modeList}
+${ctx.issueSection}${ctx.backlogSection}
 
 ## Your Memory
-Read \`memory/failure-patterns.md\` — it tracks build failures and their solutions.
+Read \`memory/strategy-notes.md\` — look for bold ideas that have been noted but not acted on, and assess whether the current roadmap is ambitious enough.
 
 ## Instructions
-1. Read \`memory/failure-patterns.md\`.
-2. Consider: Is the project in a healthy state? Are there unresolved issues that need attention?
-3. Write a plain-text memo addressed to "Producer" with your quality assessment.
-4. If the last cycle had build failures, strongly recommend repair mode.
-5. Be concise and direct. Flag blockers clearly.
+1. Read \`memory/strategy-notes.md\` to understand what creative directions have been considered.
+2. Ask yourself: is the likely next step *interesting enough*? What's the bolder version?
+3. Write a plain-text memo addressed to "Producer" that advocates for creative ambition.
+4. Challenge safe or incremental choices — propose the more exciting alternative.
+5. If community issues are listed above, identify which ones open the door to something truly exciting.
 6. Do NOT produce JSON. Just write your memo as plain text.`,
 };
 
@@ -155,5 +157,5 @@ Read \`memory/failure-patterns.md\` — it tracks build failures and their solut
 export const TEAM_ROLES: TeamRole[] = [
   gameDesignerRole,
   techLeadRole,
-  qaLeadRole,
+  creativeVisionaryRole,
 ];


### PR DESCRIPTION
The QA Lead's concerns (build health, regressions, stability) overlapped
heavily with the Technical Lead, adding little unique signal. Replace it
with a Creative Visionary that challenges safe choices and advocates for
the most ambitious version of each cycle's work — counterbalancing the
two more cautious voices already on the panel.

https://claude.ai/code/session_018LDJXQPCjceTTNacAdv2jw