### PR TITLE
feat: add Pokémon Specialist advisory role with web search

### DIFF
--- a/memory/pokemon-knowledge.md
+++ b/memory/pokemon-knowledge.md
@@ -1,0 +1,7 @@
+# Pokémon Knowledge Base
+
+Research findings about Pokémon games, ROM hacks, community expectations, and design patterns — gathered via web search by the Pokémon Specialist advisor.
+
+---
+
+*No entries yet.*

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -279,6 +279,7 @@ Update the memory files in the memory/ directory as needed:
 - memory/failure-patterns.md — new failure patterns
 - memory/strategy-notes.md — strategy updates, game design evolution, multi-cycle roadmap
 - memory/project-facts.md — project facts
+- memory/pokemon-knowledge.md — Pokémon game/ROM hack research findings (primarily updated by the Pokémon Specialist advisor)
 
 **IMPORTANT — Reflection completion (follow these steps IN ORDER)**:
 1. First, call the \`/communicate\` skill to write your reflection and next steps in Professor Oak's voice.

--- a/src/cycle/team-planner.ts
+++ b/src/cycle/team-planner.ts
@@ -146,6 +146,7 @@ Your full memory is in the \`memory/\` directory. Read these files if you need m
 - \`memory/codebase-facts.md\` — discovered facts about the pokeemerald codebase
 - \`memory/failure-patterns.md\` — build failures encountered and their solutions
 - \`memory/project-facts.md\` — build system details and configuration notes
+- \`memory/pokemon-knowledge.md\` — Pokémon game/ROM hack research findings (maintained by the Pokémon Specialist advisor)
 
 You can also read specific cycle journals in \`memory/cycles/cycle-<n>.md\` for more details on past cycles if needed.
 

--- a/src/cycle/team-roles.ts
+++ b/src/cycle/team-roles.ts
@@ -122,6 +122,60 @@ Read \`memory/failure-patterns.md\` and \`memory/codebase-facts.md\` — they co
 6. Do NOT produce JSON. Just write your memo as plain text.`,
 };
 
+const pokemonSpecialistRole: TeamRole = {
+  name: "pokemon-specialist",
+  label: "Pokémon Specialist",
+  maxTurns: 8,
+  timeout: 3 * 60 * 1000,
+  tools: "Read,Write,WebSearch",
+  buildPrompt: (ctx) => `You are the **Pokémon Specialist** advisor on a Pokémon Emerald ROM hack project called Agent Oak.
+
+Your job: research what makes great Pokémon ROM hacks, understand community expectations, and write a short advisory memo (200-400 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+
+## What makes you unique
+You have **web search** access. Use it to research:
+- Popular Pokémon ROM hacks and what makes them beloved (e.g., Radical Red, Inclement Emerald, Emerald Kaizo, Unbound, Crystal Clear)
+- ROM hacking community trends and player expectations
+- Specific game design patterns that work well in ROM hacks (difficulty tuning, QoL features, encounter design philosophy, postgame content)
+- What features or changes players praise or criticize in existing hacks
+
+You also maintain a **persistent knowledge file** at \`memory/pokemon-knowledge.md\`. This is YOUR knowledge base that grows over time.
+
+## Your knowledge-building process
+1. First, read \`memory/pokemon-knowledge.md\` to see what you already know.
+2. Based on the current cycle context, identify 1-2 **targeted research questions** that would inform the planning decision.
+3. Use WebSearch to research those questions. Be specific in your queries (e.g., "Pokémon ROM hack encounter design philosophy" not just "Pokémon ROM hacks").
+4. **Update \`memory/pokemon-knowledge.md\`** with your new findings. Add a new ## section with a descriptive heading, include key findings and source context. Keep entries concise and actionable.
+5. Write your advisory memo incorporating both prior knowledge and new research.
+
+## Context
+
+### Last Cycle Journal
+${ctx.journalContext}
+
+### Cycle Mode History
+${ctx.modeHistorySummary}
+
+### Available Modes
+${ctx.modeList}
+
+### New Community Issues
+${ctx.issueSection}
+
+### Community Backlog
+${ctx.backlogSection}
+
+## Instructions
+1. Read \`memory/pokemon-knowledge.md\` to review your accumulated knowledge.
+2. Read \`memory/strategy-notes.md\` to understand the project's current direction.
+3. Identify what research would be most useful for the next cycle's decision.
+4. Use WebSearch for 1-3 targeted searches. Don't over-search — be focused.
+5. Update \`memory/pokemon-knowledge.md\` with new findings (append a new ## section).
+6. Write a plain-text memo addressed to "Producer" with your recommendation, grounded in real-world knowledge of what works in ROM hacks.
+7. Be specific — cite examples from actual ROM hacks, reference community preferences, suggest concrete design patterns.
+8. Do NOT produce JSON. Just write your memo as plain text.`,
+};
+
 const creativeVisionaryRole: TeamRole = {
   name: "creative-visionary",
   label: "Creative Visionary",
@@ -173,4 +227,5 @@ export const TEAM_ROLES: TeamRole[] = [
   gameDesignerRole,
   techLeadRole,
   creativeVisionaryRole,
+  pokemonSpecialistRole,
 ];

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -25,6 +25,11 @@ const INITIAL_CONTENT: Record<MemoryFileName, { title: string; description: stri
     description:
       "General project information — build system details, tool versions, configuration notes.",
   },
+  "pokemon-knowledge": {
+    title: "Pokémon Knowledge Base",
+    description:
+      "Research findings about Pokémon games, ROM hacks, community expectations, and design patterns — gathered via web search by the Pokémon Specialist advisor.",
+  },
 };
 
 function memoryPath(name: MemoryFileName): string {
@@ -81,6 +86,7 @@ export function loadMemory(): Memory {
     failurePatterns: parseMemoryFile("failure-patterns"),
     strategyNotes: parseMemoryFile("strategy-notes"),
     projectFacts: parseMemoryFile("project-facts"),
+    pokemonKnowledge: parseMemoryFile("pokemon-knowledge"),
   };
 }
 
@@ -106,7 +112,7 @@ export function appendToMemory(name: MemoryFileName, heading: string, content: s
 
 /** Get a summary of all memory for inclusion in prompts */
 export function getMemorySummary(memory: Memory): string {
-  const sections = [memory.codebaseFacts, memory.failurePatterns, memory.strategyNotes, memory.projectFacts];
+  const sections = [memory.codebaseFacts, memory.failurePatterns, memory.strategyNotes, memory.projectFacts, memory.pokemonKnowledge];
 
   return sections
     .map((file) => {

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -4,6 +4,7 @@ export const MEMORY_FILES = [
   "failure-patterns",
   "strategy-notes",
   "project-facts",
+  "pokemon-knowledge",
 ] as const;
 
 export type MemoryFileName = (typeof MEMORY_FILES)[number];
@@ -28,6 +29,7 @@ export interface Memory {
   failurePatterns: MemoryFile;
   strategyNotes: MemoryFile;
   projectFacts: MemoryFile;
+  pokemonKnowledge: MemoryFile;
 }
 
 /** Token usage tracking for a cycle */


### PR DESCRIPTION
Add a fourth advisory team member — the Pokémon Specialist — that brings
external knowledge to planning decisions via web search. Unlike the
existing read-only advisors, this role:

- Has WebSearch access to research ROM hacking trends, popular hacks,
  and community expectations
- Maintains its own persistent knowledge file (memory/pokemon-knowledge.md)
  that compounds across cycles
- Has Write access to update its knowledge base during each advisory run
- Gets a longer budget (8 turns, 3 min) to accommodate web searches

Also registers pokemon-knowledge as a first-class memory file in the
memory system (types, store, prompts, team-planner).

https://claude.ai/code/session_019o26dAJMUwqC1UTor29Bc3