### PR TITLE
fix: isolate advisory agent failures and bump default max turns to 100

### DIFF
--- a/.github/workflows/agent-cycle.yml
+++ b/.github/workflows/agent-cycle.yml
@@ -11,7 +11,7 @@ on:
       max_tool_calls:
         description: "Max tool calls per cycle"
         required: false
-        default: "50"
+        default: "100"
 
   # Run every 8 hours automatically
   schedule:
@@ -34,7 +34,7 @@ jobs:
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ANTHROPIC_MODEL: ${{ inputs.model || 'claude-sonnet-4-20250514' }}
-      MAX_TOOL_CALLS_PER_CYCLE: ${{ inputs.max_tool_calls || '50' }}
+      MAX_TOOL_CALLS_PER_CYCLE: ${{ inputs.max_tool_calls || '100' }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_REPO: ${{ github.repository }}
       BASE_ROM_URL: ${{ secrets.BASE_ROM_URL }}

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -161,7 +161,7 @@ async function runImplementationPhase(
   const timeout = usingDeepSeek
     ? parseInt(process.env.DEEPSEEK_API_TIMEOUT_MS ?? CODING_PHASE_DEFAULT_TIMEOUT_MS.toString(), 10)
     : 30 * 60 * 1000;
-  const maxTurns = parseInt(process.env.MAX_TOOL_CALLS_PER_CYCLE ?? "50", 10);
+  const maxTurns = parseInt(process.env.MAX_TOOL_CALLS_PER_CYCLE ?? "100", 10);
 
   log.info(`  → Model profile: ${usingDeepSeek ? `DeepSeek (${model ?? "deepseek-chat"})` : `Anthropic (${model ?? "default"})`} [mode: ${plan.mode}]`);
   log.info(`  → Task: ${plan.objective}`);

--- a/src/cycle/team-planner.ts
+++ b/src/cycle/team-planner.ts
@@ -17,8 +17,8 @@ async function runAdvisoryRole(
   role: TeamRole,
   ctx: TeamContext,
 ): Promise<{ name: string; label: string; memo: string }> {
-  const prompt = role.buildPrompt(ctx);
   try {
+    const prompt = role.buildPrompt(ctx);
     logger.info(`  [Team] Running ${role.label} advisor...`);
     const result = await runClaudeCode(prompt, {
       maxTurns: role.maxTurns,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ async function main() {
   logger.info("Agent Oak starting up...");
   logger.info(`Model: ${process.env.ANTHROPIC_MODEL ?? "(default)"}`);
   logger.info(`Anthropic Base URL: ${process.env.ANTHROPIC_BASE_URL ?? "(default)"}`);
-  logger.info(`Max tool calls/cycle: ${process.env.MAX_TOOL_CALLS_PER_CYCLE ?? "50"}`);
+  logger.info(`Max tool calls/cycle: ${process.env.MAX_TOOL_CALLS_PER_CYCLE ?? "100"}`);
 
   try {
     await runCycle();


### PR DESCRIPTION
## Summary

- **Fix agent failure isolation**: `role.buildPrompt(ctx)` was called outside
  the `try-catch` in `runAdvisoryRole`. In an `async` function, a synchronous
  throw becomes a rejected promise — causing `Promise.all` to short-circuit and
  discard results from other still-running advisors. Moving it inside the
  try-catch ensures the function always resolves with a graceful fallback, so
  one failure never affects the others.
- **Bump default max turns**: `MAX_TOOL_CALLS_PER_CYCLE` default raised from
  `50` → `100` in `runner.ts`, `index.ts`, and the GitHub Actions workflow.