### PR TITLE
feat: add custom GitHub Actions runner image to eliminate per-run set…

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System dependencies for pokeemerald build + agent tooling
+RUN apt-get update -qq && apt-get install -y -qq \
+    gcc-arm-none-eabi \
+    binutils-arm-none-eabi \
+    libpng-dev \
+    build-essential \
+    git \
+    curl \
+    make \
+    rsync \
+    unzip \
+    ca-certificates \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build and install agbcc (GBA-specific C compiler) to /opt/agbcc
+# The workflow copies this to pokeemerald/tools/agbcc after checkout
+RUN git clone --depth 1 https://github.com/pret/agbcc.git /tmp/agbcc \
+    && cd /tmp/agbcc \
+    && ./build.sh \
+    && ./install.sh /opt/agbcc \
+    && rm -rf /tmp/agbcc
+
+# Build Flips (IPS patcher) from source — flatpak is not usable in containers
+RUN git clone --depth 1 https://github.com/Alcaro/Flips.git /tmp/flips \
+    && cd /tmp/flips \
+    && make flips \
+    && cp flips /usr/local/bin/flips \
+    && rm -rf /tmp/flips
+
+# Install RTK (Rust Token Killer) for Claude Code cost tracking
+RUN curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh \
+    && cp /root/.local/bin/rtk /usr/local/bin/rtk \
+    && rm -rf /root/.local/bin/rtk
+
+# Sanity-check all required tools are present and executable
+RUN arm-none-eabi-gcc --version \
+    && /opt/agbcc/bin/agbcc --version 2>&1 | head -1 \
+    && flips --version 2>&1 | head -1 || true \
+    && rtk --version 2>&1 | head -1 || true

--- a/.github/workflows/agent-cycle.yml
+++ b/.github/workflows/agent-cycle.yml
@@ -31,6 +31,9 @@ permissions:
 jobs:
   run-cycle:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/agentoak-runner:latest
+      options: --user root
     env:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ANTHROPIC_MODEL: ${{ inputs.model || 'claude-sonnet-4-20250514' }}
@@ -52,17 +55,6 @@ jobs:
       - name: Fetch full history for git operations
         run: git fetch --unshallow origin main 2>/dev/null || true
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -74,58 +66,8 @@ jobs:
       - name: Install Claude Code CLI
         run: npm install -g @anthropic-ai/claude-code
 
-      - name: Cache ARM toolchain
-        id: cache-arm
-        uses: actions/cache@v4
-        with:
-          path: ~/arm-toolchain
-          key: arm-toolchain-${{ runner.os }}-v1
-
-      - name: Install ARM toolchain & build deps
-        if: steps.cache-arm.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq gcc-arm-none-eabi binutils-arm-none-eabi libpng-dev
-          # Snapshot installed files for cache
-          mkdir -p ~/arm-toolchain
-          dpkg -L gcc-arm-none-eabi binutils-arm-none-eabi libpng-dev | \
-            grep -E '^/(usr|lib)' | sort -u | \
-            rsync -a --files-from=- / ~/arm-toolchain/
-
-      - name: Restore ARM toolchain from cache
-        if: steps.cache-arm.outputs.cache-hit == 'true'
-        run: sudo rsync -a ~/arm-toolchain/ /
-
-      - name: Cache agbcc
-        id: cache-agbcc
-        uses: actions/cache@v4
-        with:
-          path: pokeemerald/tools/agbcc
-          key: agbcc-${{ runner.os }}-v1
-
-      - name: Build & install agbcc
-        if: steps.cache-agbcc.outputs.cache-hit != 'true'
-        run: |
-          git clone --depth 1 https://github.com/pret/agbcc.git /tmp/agbcc
-          cd /tmp/agbcc
-          ./build.sh
-          ./install.sh "${{ github.workspace }}/pokeemerald"
-
-      - name: Cache Flatpak installation
-        id: cache-flatpak
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.local/share/flatpak
-            /var/lib/flatpak
-          key: flatpak-flips-${{ runner.os }}-v1
-
-      - name: Install Flips (IPS patcher) via Flatpak
-        if: steps.cache-flatpak.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get install -y -qq flatpak
-          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install --noninteractive flathub com.github.Alcaro.Flips
+      - name: Copy agbcc into workspace
+        run: cp -r /opt/agbcc ${{ github.workspace }}/pokeemerald/tools/agbcc
 
       - name: Cache base ROM
         uses: actions/cache@v4
@@ -138,23 +80,8 @@ jobs:
           git config user.name "Agent Oak [bot]"
           git config user.email "agent-oak[bot]@users.noreply.github.com"
 
-      - name: Cache RTK binary
-        id: cache-rtk
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/bin/rtk
-          key: rtk-${{ runner.os }}-v1
-
-      - name: Install RTK (Rust Token Killer)
-        if: steps.cache-rtk.outputs.cache-hit != 'true'
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
-
       - name: Register RTK hook with Claude Code
-        run: |
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          export PATH="$HOME/.local/bin:$PATH"
-          rtk init -g --auto-patch
+        run: rtk init -g --auto-patch
 
       - name: Run agent cycle (attempt 1)
         id: attempt1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,37 @@
+name: Build Runner Image
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/docker/Dockerfile']
+  # Monthly rebuild to pick up base image security patches
+  schedule:
+    - cron: '0 4 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push runner image
+        uses: docker/build-push-action@v5
+        with:
+          context: .github/docker
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/agentoak-runner:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/src/release/patcher.ts
+++ b/src/release/patcher.ts
@@ -2,7 +2,7 @@
  * IPS patch generation and base ROM management.
  *
  * Creates IPS (International Patching System) format patches using Flips
- * (Floating IPS), installed via Flatpak as com.github.Alcaro.Flips.
+ * (Floating IPS), pre-installed in the runner image as the `flips` binary.
  * The base ROM is downloaded on first use and cached locally.
  */
 
@@ -129,7 +129,7 @@ function hashFile(filePath: string): string {
 
 /**
  * Generate an IPS patch by comparing the base ROM against the built ROM
- * using Flips (com.github.Alcaro.Flips) installed via Flatpak.
+ * using the `flips` binary pre-installed in the runner image.
  * Returns the patch as a Buffer, or null if generation fails.
  */
 export async function generateIPSPatch(): Promise<Buffer | null> {
@@ -144,11 +144,9 @@ export async function generateIPSPatch(): Promise<Buffer | null> {
   const patchPath = path.join(BASE_ROM_DIR, "patch.ips");
 
   try {
-    logger.info("Generating IPS patch using Flips (com.github.Alcaro.Flips)...");
+    logger.info("Generating IPS patch using Flips...");
 
-    await execFileAsync("flatpak", [
-      "run",
-      "com.github.Alcaro.Flips",
+    await execFileAsync("flips", [
       "--create",
       baseRomPath,
       BUILT_ROM_PATH,
@@ -162,7 +160,7 @@ export async function generateIPSPatch(): Promise<Buffer | null> {
 
     const patch = fs.readFileSync(patchPath);
     fs.unlinkSync(patchPath);
-    logger.info(`IPS patch generated via Flips (com.github.Alcaro.Flips): ${patch.length} bytes`);
+    logger.info(`IPS patch generated: ${patch.length} bytes`);
     return patch;
   } catch (err) {
     logger.error(


### PR DESCRIPTION
…up overhead

Pre-bake ARM toolchain (gcc-arm-none-eabi), agbcc GBA compiler, Flips IPS patcher, and RTK into a Docker image published to ghcr.io. This removes 4 cache restore operations and all apt/flatpak install steps from every cycle run, saving ~4-6 minutes of setup time per run.

Changes:
- .github/docker/Dockerfile: Ubuntu 22.04 image with all build deps pre-installed (agbcc built to /opt/agbcc, Flips built from source as binary, RTK installed)
- .github/workflows/docker-build.yml: CI workflow to build and push the image on Dockerfile changes and monthly for security patches
- .github/workflows/agent-cycle.yml: use container directive, remove all caching and install steps, add single step to copy /opt/agbcc into workspace
- src/release/patcher.ts: call `flips` binary directly instead of via flatpak

https://claude.ai/code/session_01Y5TzXHATfjZgEMJJorbZtQ