### PR TITLE
fix: improve community issue lifecycle handling

### DIFF
--- a/src/cycle/planner.ts
+++ b/src/cycle/planner.ts
@@ -59,6 +59,10 @@ export const CYCLE_PLAN_SCHEMA: Record<string, unknown> = {
             type: "string",
             description: "A brief, friendly response to post as a comment on the issue",
           },
+          partial: {
+            type: "boolean",
+            description: "Set to true when accepting a complex issue that will require multiple cycles to fully implement. The issue will stay open and remain in the backlog so you can continue working on it next cycle. Only valid with action 'accept'.",
+          },
         },
         required: ["issueNumber", "action", "response"],
         additionalProperties: false,

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -26,7 +26,7 @@ import {
 } from "../git/committer.js";
 import { validateCycle } from "../reflection/validator.js";
 import type { ValidationResult } from "../reflection/validator.js";
-import { fetchNewCommunityIssues, formatIssuesForPrompt, executeIssueActions, createHelpRequest, readIssueBacklog, updateIssueBacklog } from "../github/issues.js";
+import { fetchNewCommunityIssues, formatIssuesForPrompt, executeIssueActions, createHelpRequest, readIssueBacklog, updateIssueBacklog, postIssueClosingComment } from "../github/issues.js";
 import { closeIssue, addLabelsToIssue, AGENT_LABELS } from "../github/client.js";
 import { cycleLogger } from "../utils/logger.js";
 import { PROJECT_ROOT } from "../utils/paths.js";
@@ -99,6 +99,17 @@ async function runPlanningPhase(
   if (newIssueActions.length > 0) {
     log.info(`  Executing ${newIssueActions.length} issue action(s)...`);
     await executeIssueActions(newIssueActions);
+  }
+
+  // Post comments on backlog issues being accepted this cycle.
+  // These were already reviewed in a prior cycle (so executeIssueActions was skipped above),
+  // but now that the agent is picking them up we should post the acceptance/in-progress comment.
+  const backlogAcceptActions = plan.issueActions.filter(
+    (a) => !communityIssueNumbers.has(a.issueNumber) && a.action === "accept",
+  );
+  if (backlogAcceptActions.length > 0) {
+    log.info(`  Posting comments on ${backlogAcceptActions.length} backlog issue(s) being accepted...`);
+    await executeIssueActions(backlogAcceptActions);
   }
 
   // Update the deferred-issue backlog based on this cycle's actions
@@ -533,11 +544,26 @@ export async function runCycle(): Promise<void> {
       process.exitCode = 1;
     }
 
-    // Close accepted issues after successful commit (not reverted)
+    // Close accepted issues after successful commit (not reverted).
+    // Partial issues (multi-cycle work) stay open and remain in the backlog.
+    // Always post a closing comment before closing so the community knows what was done.
     if (acceptedIssueNumbers.length > 0 && commitHash && !reverted) {
-      log.info(`  Closing ${acceptedIssueNumbers.length} accepted issue(s)...`);
-      for (const issueNumber of acceptedIssueNumbers) {
-        await closeIssue(issueNumber, "completed");
+      const partialNumbers = new Set(
+        plan.issueActions
+          .filter((a) => a.action === "accept" && a.partial)
+          .map((a) => a.issueNumber),
+      );
+      const closingNumbers = acceptedIssueNumbers.filter((n) => !partialNumbers.has(n));
+      if (closingNumbers.length > 0) {
+        log.info(`  Closing ${closingNumbers.length} completed issue(s)...`);
+        const closingSummary = reflection.cycleSummary || plan.objective;
+        for (const issueNumber of closingNumbers) {
+          await postIssueClosingComment(issueNumber, closingSummary);
+          await closeIssue(issueNumber, "completed");
+        }
+      }
+      if (partialNumbers.size > 0) {
+        log.info(`  Kept ${partialNumbers.size} partial issue(s) open for future cycles.`);
       }
     }
 

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -37,6 +37,9 @@ export interface IssueAction {
   issueNumber: number;
   action: "accept" | "defer" | "reject" | "need-info";
   response: string;
+  /** When true, the issue requires multiple cycles to complete. The issue stays open and
+   *  remains in the backlog for future cycles. Only meaningful with action "accept". */
+  partial?: boolean;
 }
 
 /** A help request the agent wants to raise */

--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -71,7 +71,8 @@ export function updateIssueBacklog(
         changed = true;
       }
     } else if (action.action === "accept" || action.action === "reject") {
-      if (existing.has(action.issueNumber)) {
+      // Keep in backlog when it's a partial (multi-cycle) accept — the work isn't done yet
+      if (existing.has(action.issueNumber) && !(action.action === "accept" && action.partial)) {
         existing.delete(action.issueNumber);
         changed = true;
       }
@@ -201,6 +202,8 @@ const ACTION_PREFIX_MAP: Record<IssueAction["action"], string> = {
   "need-info": "🤖 **Agent Oak — More Info Needed**\n\n",
 };
 
+const PARTIAL_ACCEPT_PREFIX = "🤖 **Agent Oak — In Progress**\n\n";
+
 /**
  * Execute the planner's decisions on community issues.
  *
@@ -216,7 +219,9 @@ export async function executeIssueActions(actions: IssueAction[]): Promise<void>
   for (const action of actions) {
     try {
       // Post the agent's response as a comment
-      const prefix = ACTION_PREFIX_MAP[action.action] ?? "";
+      const prefix = (action.action === "accept" && action.partial)
+        ? PARTIAL_ACCEPT_PREFIX
+        : (ACTION_PREFIX_MAP[action.action] ?? "");
       await commentOnIssue(action.issueNumber, prefix + action.response);
 
       // Add the action label + reviewed label
@@ -240,6 +245,15 @@ export async function executeIssueActions(actions: IssueAction[]): Promise<void>
       );
     }
   }
+}
+
+/**
+ * Post a closing comment on an issue explaining what was accomplished.
+ * Should be called immediately before closing an accepted issue.
+ */
+export async function postIssueClosingComment(issueNumber: number, summary: string): Promise<void> {
+  const body = `🤖 **Agent Oak — Work Complete**\n\n${summary}`;
+  await commentOnIssue(issueNumber, body);
 }
 
 /**


### PR DESCRIPTION
- Add `partial` flag to IssueAction so the agent can accept complex issues across multiple cycles without immediately closing them. Partial issues stay open and remain in the backlog for future cycles.

- Post a "Work Complete" closing comment before closing any accepted issue, explaining what was done in the cycle. Previously issues were silently closed.

- Post an acceptance/in-progress comment on backlog issues when they are picked up. Previously, deferred issues accepted from the backlog received no comment at all since they were filtered from executeIssueActions.

- Add `postIssueClosingComment` utility in issues.ts for the runner to call before closing.

https://claude.ai/code/session_01Sjn1TKy1LzAKECFUpNw64Y