### PR TITLE
feat: weight community issues by upvotes

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -23,6 +23,7 @@ export interface GitHubIssue {
   state: "open" | "closed";
   author: string;
   createdAt: string;
+  upvotes: number;
 }
 
 export interface GitHubComment {
@@ -153,6 +154,7 @@ export async function fetchOpenIssues(labels?: string[]): Promise<GitHubIssue[]>
         state: issue.state as "open" | "closed",
         author: issue.user?.login ?? "unknown",
         createdAt: issue.created_at,
+        upvotes: issue.reactions?.["+1"] ?? 0,
       }));
   } catch (err) {
     logger.error(`Failed to fetch GitHub issues: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -127,8 +127,9 @@ export async function fetchNewCommunityIssues(): Promise<GitHubIssue[]> {
       );
     });
 
-    // Limit to most recent N issues
-    const limited = communityIssues.slice(0, MAX_ISSUES_PER_CYCLE);
+    // Sort by upvotes descending so the most community-supported issues surface first
+    const sorted = communityIssues.sort((a, b) => b.upvotes - a.upvotes);
+    const limited = sorted.slice(0, MAX_ISSUES_PER_CYCLE);
 
     if (limited.length > 0) {
       logger.info(`Found ${limited.length} new community issue(s) to review.`);
@@ -162,9 +163,10 @@ export function formatIssuesForPrompt(issues: GitHubIssue[]): string {
         : issue.body;
 
     const labels = issue.labels.length > 0 ? ` [${issue.labels.join(", ")}]` : "";
+    const upvoteStr = issue.upvotes > 0 ? ` | **👍 Upvotes**: ${issue.upvotes}` : "";
 
     return `### Issue #${issue.number}: ${issue.title}${labels}
-**Author**: ${issue.author} | **Created**: ${issue.createdAt}
+**Author**: ${issue.author} | **Created**: ${issue.createdAt}${upvoteStr}
 
 ${truncatedBody}`;
   });


### PR DESCRIPTION
- Add `upvotes` field to GitHubIssue (mapped from GitHub reactions['+1'])
- Sort community issues by upvotes descending before presenting to planner
- Display upvote count in formatted issue prompt so the planner can weigh community support

No extra API calls needed — upvote counts come from the existing listForRepo response.

https://claude.ai/code/session_01DSgnAcKR7Hi1ctf21vniNN