### PR TITLE
fix: only close issues when fully delivered; acknowledge partial deli…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,16 +85,53 @@ The key is to be **ambitious and intentional**. Each cycle should serve the larg
 When you have finished your work for this cycle, output the following HTML comment marker on its own line:
 
 ```
-<!-- CYCLE_COMPLETE: {"summary": "Oak-voice reflection on the cycle", "changes": ["Player-facing change 1", "Player-facing change 2"], "next_steps": "What to try in the next cycle"} -->
+<!-- CYCLE_COMPLETE: {"summary": "Oak-voice reflection on the cycle", "changes": ["Player-facing change 1", "Player-facing change 2"], "next_steps": "What to try in the next cycle", "issue_outcomes": [{"number": 23, "status": "complete"}, {"number": 7, "status": "partial", "decision": "defer", "reason": "Added NPC dialogue but event trigger rewrites are deferred to a future cycle."}]} -->
 ```
 
-This marker is parsed by the agent runner. Always include all three fields:
+This marker is parsed by the agent runner. Always include all fields:
 
 | Field | Purpose |
 |---|---|
 | `summary` | Professor Oak narrative reflection (used in journal/release description fallback) |
 | `changes` | Array of short, plain-English player-facing changelog entries (e.g. `"Reduced TM prices from 3,000 to 1,500 Pokédollars"`). These become the bullet points in the GitHub release. Use `[]` if no ROM changes were made. |
 | `next_steps` | Oak-voice description of what to do next cycle |
+| `issue_outcomes` | **Required when any issues were accepted this cycle.** Array of outcome objects — one per accepted issue. See below. |
+
+### issue_outcomes — Reporting Issue Delivery
+
+**You must report an outcome for every issue you accepted this cycle.** This is how the runner decides whether to close an issue or keep it open.
+
+Each outcome object has these fields:
+
+| Field | Required | Values | Purpose |
+|---|---|---|---|
+| `number` | yes | integer | The issue number |
+| `status` | yes | `"complete"` or `"partial"` | Was the ask fully implemented? |
+| `decision` | if partial | `"defer"` or `"reject"` | What to do with the remaining work |
+| `reason` | if partial | string | Plain-English explanation posted as a comment on the issue |
+
+**Rules:**
+- `"complete"` — the issue's ask was fully implemented. The runner will close the issue.
+- `"partial"` — only part of the ask was implemented. You MUST also set `decision` and `reason`.
+  - `"defer"` — keep the issue open and return it to the backlog for a future cycle.
+  - `"reject"` — decline the remaining work; the issue will be closed without full delivery.
+- **Never omit `issue_outcomes` when you accepted issues.** Omitting it causes the runner to close issues as if they were complete, even if they weren't.
+- **Never mark an issue `"complete"` unless its full ask was implemented.** If you only partially addressed it, use `"partial"`.
+
+**Example — issue fully delivered:**
+```json
+{"number": 23, "status": "complete"}
+```
+
+**Example — issue partially delivered, deferred:**
+```json
+{"number": 23, "status": "partial", "decision": "defer", "reason": "Added five migration-reactive NPCs as requested. The deeper ask — rewriting Magma/Aqua event triggers to reflect the migration — requires a dedicated feature cycle and is deferred to my next pass."}
+```
+
+**Example — issue partially delivered, remaining work rejected:**
+```json
+{"number": 7, "status": "partial", "decision": "reject", "reason": "Implemented the sprite recolour as asked. The second part of the request (adding new animations) is out of scope for the current project direction."}
+```
 
 ## Public Communication
 

--- a/src/agent/output-parser.ts
+++ b/src/agent/output-parser.ts
@@ -5,6 +5,23 @@
  * object, OR a single JSON array containing all messages.
  */
 
+/**
+ * Per-issue delivery outcome reported by the implementation agent in CYCLE_COMPLETE.
+ *
+ * The agent must include an entry for every accepted issue.
+ * - "complete": the issue was fully implemented; the runner will close it.
+ * - "partial": the implementation only partially addressed the issue.
+ *   The agent must also set `decision` ("defer" to keep it open for a future
+ *   cycle, or "reject" to close it without completing the work) and `reason`
+ *   (a plain-English explanation posted as a comment on the issue).
+ */
+export interface IssueOutcome {
+  number: number;
+  status: "complete" | "partial";
+  decision?: "defer" | "reject";
+  reason?: string;
+}
+
 export interface ClaudeCodeResult {
   actions: ActionRecord[];
   filesModified: string[];
@@ -13,6 +30,12 @@ export interface ClaudeCodeResult {
   /** Structured changelog entries for the release (e.g. ["Reduced TM prices", "Added held items"]) */
   cycleChanges: string[];
   nextSteps: string;
+  /**
+   * Delivery outcomes for accepted issues, keyed by issue number.
+   * Populated from the issueOutcomes field in the CYCLE_COMPLETE marker.
+   * Issues not listed here are treated as fully complete (backward compat).
+   */
+  issueOutcomes: IssueOutcome[];
   tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number };
   toolCallCount: number;
   /** The text from the final "result" message (e.g. structured JSON from --json-schema) */
@@ -38,6 +61,7 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
   let cycleSummary = "";
   let cycleChanges: string[] = [];
   let nextSteps = "";
+  let issueOutcomes: IssueOutcome[] = [];
   let toolCallCount = 0;
   let cycleMarkerFound = false;
   const preMarkerTexts: string[] = [];
@@ -97,12 +121,22 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
               summary?: string;
               changes?: string[];
               next_steps?: string;
+              issue_outcomes?: IssueOutcome[];
             };
             cycleSummary = parsed.summary ?? cycleSummary;
             if (Array.isArray(parsed.changes) && parsed.changes.length > 0) {
               cycleChanges = parsed.changes.filter((c): c is string => typeof c === "string");
             }
             nextSteps = parsed.next_steps ?? nextSteps;
+            if (Array.isArray(parsed.issue_outcomes) && parsed.issue_outcomes.length > 0) {
+              issueOutcomes = parsed.issue_outcomes.filter(
+                (o): o is IssueOutcome =>
+                  o !== null &&
+                  typeof o === "object" &&
+                  typeof o.number === "number" &&
+                  (o.status === "complete" || o.status === "partial"),
+              );
+            }
           } catch {
             // Malformed JSON in marker — ignore
           }
@@ -207,6 +241,7 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
     cycleSummary,
     cycleChanges,
     nextSteps,
+    issueOutcomes,
     tokenUsage: {
       inputTokens: totalInputTokens,
       outputTokens: totalOutputTokens,

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -26,7 +26,7 @@ import {
 } from "../git/committer.js";
 import { validateCycle } from "../reflection/validator.js";
 import type { ValidationResult } from "../reflection/validator.js";
-import { fetchNewCommunityIssues, formatIssuesForPrompt, executeIssueActions, createHelpRequest, readIssueBacklog, updateIssueBacklog, postIssueClosingComment } from "../github/issues.js";
+import { fetchNewCommunityIssues, formatIssuesForPrompt, executeIssueActions, createHelpRequest, readIssueBacklog, updateIssueBacklog, postIssueClosingComment, postIssuePartialDeliveryComment } from "../github/issues.js";
 import { closeIssue, addLabelsToIssue, AGENT_LABELS } from "../github/client.js";
 import { cycleLogger } from "../utils/logger.js";
 import { PROJECT_ROOT } from "../utils/paths.js";
@@ -545,15 +545,49 @@ export async function runCycle(): Promise<void> {
     }
 
     // Close accepted issues after successful commit (not reverted).
-    // Partial issues (multi-cycle work) stay open and remain in the backlog.
-    // Always post a closing comment before closing so the community knows what was done.
+    //
+    // Three categories of accepted issues:
+    // 1. "partial" flag at planning time — multi-cycle work, stays open in backlog (unchanged).
+    // 2. issueOutcomes[status="partial"] from CYCLE_COMPLETE — agent delivered only part of
+    //    what was asked. Post a partial-delivery comment; either defer (keep open, re-backlog)
+    //    or reject (close as not_planned) based on the agent's decision field.
+    // 3. Everything else — fully implemented; post closing comment and close as "completed".
     if (acceptedIssueNumbers.length > 0 && commitHash && !reverted) {
-      const partialNumbers = new Set(
+      // Issues the planner explicitly flagged as multi-cycle at planning time
+      const plannedPartialNumbers = new Set(
         plan.issueActions
           .filter((a) => a.action === "accept" && a.partial)
           .map((a) => a.issueNumber),
       );
-      const closingNumbers = acceptedIssueNumbers.filter((n) => !partialNumbers.has(n));
+
+      // Post-implementation outcomes reported in the CYCLE_COMPLETE marker
+      const outcomeMap = new Map(
+        implResult.issueOutcomes.map((o) => [o.number, o]),
+      );
+
+      const closingNumbers: number[] = [];
+      const deferNumbers: number[] = [];
+      const rejectNumbers: number[] = [];
+
+      for (const issueNumber of acceptedIssueNumbers) {
+        if (plannedPartialNumbers.has(issueNumber)) {
+          // Already handled as a planned multi-cycle issue — leave open, skip.
+          continue;
+        }
+        const outcome = outcomeMap.get(issueNumber);
+        if (outcome?.status === "partial") {
+          if ((outcome.decision ?? "defer") === "reject") {
+            rejectNumbers.push(issueNumber);
+          } else {
+            deferNumbers.push(issueNumber);
+          }
+        } else {
+          // No outcome entry or status="complete" — treat as fully delivered.
+          closingNumbers.push(issueNumber);
+        }
+      }
+
+      // Fully completed issues
       if (closingNumbers.length > 0) {
         log.info(`  Closing ${closingNumbers.length} completed issue(s)...`);
         const closingSummary = reflection.cycleSummary || plan.objective;
@@ -562,8 +596,37 @@ export async function runCycle(): Promise<void> {
           await closeIssue(issueNumber, "completed");
         }
       }
-      if (partialNumbers.size > 0) {
-        log.info(`  Kept ${partialNumbers.size} partial issue(s) open for future cycles.`);
+
+      // Partially delivered → defer: keep open, re-add to backlog
+      if (deferNumbers.length > 0) {
+        log.info(`  Deferring ${deferNumbers.length} partially-delivered issue(s) back to backlog...`);
+        for (const issueNumber of deferNumbers) {
+          const outcome = outcomeMap.get(issueNumber)!;
+          const reason = outcome.reason ?? "This cycle's work partially addressed this issue.";
+          await postIssuePartialDeliveryComment(issueNumber, reason, "defer");
+          await addLabelsToIssue(issueNumber, [AGENT_LABELS.deferred]);
+          // Re-add to backlog so it surfaces in a future cycle
+          updateIssueBacklog(
+            [{ issueNumber, action: "defer", response: reason }],
+            new Map([[issueNumber, { number: issueNumber, title: `Issue #${issueNumber}`, body: "", labels: [], state: "open", author: "", createdAt: "", upvotes: 0 }]]),
+          );
+        }
+      }
+
+      // Partially delivered → reject: close without completing
+      if (rejectNumbers.length > 0) {
+        log.info(`  Closing ${rejectNumbers.length} partially-delivered issue(s) as rejected...`);
+        for (const issueNumber of rejectNumbers) {
+          const outcome = outcomeMap.get(issueNumber)!;
+          const reason = outcome.reason ?? "This cycle's work only partially addressed this issue, and the remaining work will not be pursued.";
+          await postIssuePartialDeliveryComment(issueNumber, reason, "reject");
+          await addLabelsToIssue(issueNumber, [AGENT_LABELS.rejected]);
+          await closeIssue(issueNumber, "not_planned");
+        }
+      }
+
+      if (plannedPartialNumbers.size > 0) {
+        log.info(`  Kept ${plannedPartialNumbers.size} planned multi-cycle issue(s) open.`);
       }
     }
 

--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -259,6 +259,27 @@ export async function postIssueClosingComment(issueNumber: number, summary: stri
 }
 
 /**
+ * Post a comment on an issue acknowledging that the implementation was partial.
+ *
+ * Called when the agent accepted an issue but only partially delivered on it.
+ * The `decision` field controls what happens next:
+ * - "defer": the issue stays open and goes back into the work queue.
+ * - "reject": the remaining work is declined; the issue will be closed.
+ */
+export async function postIssuePartialDeliveryComment(
+  issueNumber: number,
+  reason: string,
+  decision: "defer" | "reject",
+): Promise<void> {
+  const decisionLine =
+    decision === "defer"
+      ? "I'm adding this back to my work queue to pick up in a future cycle."
+      : "After reflection, I've decided not to pursue the remaining work — it falls outside the current project scope.";
+  const body = `🤖 **Agent Oak — Partial Delivery**\n\n${reason}\n\n${decisionLine}`;
+  await commentOnIssue(issueNumber, body);
+}
+
+/**
  * Create a help-request issue when the agent needs human input.
  * Returns the new issue number, or null on failure.
  */


### PR DESCRIPTION
…very

Previously, any accepted issue was closed after a successful commit regardless of whether the implementation actually addressed the ask.

This adds an `issue_outcomes` field to the CYCLE_COMPLETE marker that the agent fills out for every accepted issue, distinguishing between:
- "complete": fully implemented → close as before
- "partial" + "defer": post a partial-delivery comment, re-add to the work backlog, keep the issue open
- "partial" + "reject": post a partial-delivery comment explaining why remaining work is declined, then close as not_planned

Changes:
- output-parser.ts: IssueOutcome type + parse issue_outcomes from marker
- issues.ts: postIssuePartialDeliveryComment() for public-facing notice
- runner.ts: route each accepted issue through the outcome map instead of closing all of them unconditionally
- CLAUDE.md: document issue_outcomes field, rules, and examples

https://claude.ai/code/session_01H6B5ME1wJBgoooPwjpiwdM