### PR TITLE
Fix agent memory issues causing repeated NPC dialogue work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,38 @@ These memories persist across cycles. **Update them as you learn.** They are you
 - When a build fails, record the failure pattern so you can avoid it next time
 - Think about the big picture — what kind of ROM hack do you want to create?
 
+### Memory Maintenance Rules
+
+Memory files are your most critical resource — but only if they stay **concise and current**. Follow these rules to prevent bloat and staleness:
+
+**Size budgets** (approximate line counts — trim when exceeded):
+
+| File | Budget | Action if over budget |
+|---|---|---|
+| `completed-work.md` | 200 lines | Collapse old entries — see below |
+| `strategy-notes.md` | 200 lines | Archive or delete obsolete sections — see below |
+| `codebase-facts.md` | 150 lines | Remove facts you've internalized or that are obvious |
+| `failure-patterns.md` | 100 lines | Remove patterns for errors you haven't hit in 10+ cycles |
+| `project-facts.md` | 80 lines | Should rarely grow — only add genuinely new infra facts |
+
+**Every 10 cycles**, do a memory maintenance pass at the start of your cycle:
+1. Check line counts of all memory files
+2. Prune anything that's obsolete, redundant, or no longer useful
+3. In `completed-work.md`: if a section has many entries from 20+ cycles ago that you're unlikely to re-touch, collapse them into a single summary line (e.g., "Cycles 2-14: Starters, encounters, trainer teams — see git history for details")
+4. In `strategy-notes.md`: delete completed roadmap items, obsolete plans, and research notes for decisions already made. Keep only the current vision, active roadmap, and live technical reference.
+
+**What to keep vs. discard:**
+
+| Keep | Discard |
+|---|---|
+| Current roadmap and next-cycle plans | Completed roadmap items older than 10 cycles |
+| Active design decisions still being implemented | Research/analysis for decisions already made |
+| Failure patterns you've hit in the last 10 cycles | Old failure patterns you haven't seen recently |
+| File modification records for files you might re-touch | Detailed per-NPC dialogue tables (use `completed-work.md` file-level entries instead) |
+| Technical reference you actively consult | Detailed cycle plans from long-completed cycles |
+
+**When adding new content to any memory file**, check if it makes existing content redundant. Replace, don't append. Memory files should represent **current state**, not an append-only log.
+
 ## How Cycles Work
 
 Each cycle, you decide what to do. You should always be advancing the ROM hack toward a strong creative vision. You might:

--- a/memory/completed-work.md
+++ b/memory/completed-work.md
@@ -12,6 +12,13 @@ Before modifying ANY pokeemerald file:
 2. If found, the file was ALREADY modified — read it first to see current state
 3. If you still want to change it, explain WHY in your cycle journal (improvement, not ignorance)
 
+## Maintenance
+
+- **After every cycle**: add rows for each file you modified (file path, what changed, cycle number, notes)
+- **Every 10 cycles**: if this file exceeds ~200 lines, collapse old stable sections into summary lines (e.g., "Cycles 2-14: Starters, encounters, trainer teams — all complete, see git history")
+- **When a file is re-modified**: update the existing row's cycle number and notes — don't add a duplicate row. Use comma-separated cycle numbers (e.g., "27, 36")
+- **Keep the "Files Modified 3+ Times" section** at the bottom current — it flags regression risk
+
 ---
 
 ## Starters & Core Mechanics

--- a/memory/strategy-notes.md
+++ b/memory/strategy-notes.md
@@ -2,6 +2,8 @@
 
 High-level strategies, ideas for the ROM hack, what to try next, and lessons about approach.
 
+> **Maintenance**: Keep this file under ~200 lines. Delete completed roadmap items older than 10 cycles. Remove research/analysis for decisions already made. This file is for *current* vision, *active* plans, and *live* technical reference — not a historical archive.
+
 ---
 
 # LEGENDS OF HOENN — Game Design Document


### PR DESCRIPTION
Cycle 36 rewrote gym leader/rival/villain dialogue believing it was vanilla, but it had already been updated in cycles 25/27/32/33. Root cause: strategy-notes.md was 1073 lines with critical tracking data buried, and no verification step existed before modifying files.

Changes:
- Create memory/completed-work.md: structured file-level registry of all modifications, organized by system (not by cycle), so the agent can quickly look up whether a file was already modified
- Trim strategy-notes.md from 1073 → 150 lines: removed obsolete cycle-6/7/8 plans, pokeemerald-expansion analysis (300+ lines), gym difficulty audit, NPC tables (now in completed-work.md)
- Add mandatory pre-modification verification to CLAUDE.md: agent must check completed-work.md AND run git log on target files before modifying them; must never claim content is "vanilla" without reading
- Fix roadmap: cycle 37 correctly shows release prep, not dialogue work that was already done
- Add completed-work.md to memory system table in CLAUDE.md with "CHECK FIRST every cycle" instruction

https://claude.ai/code/session_017yUVv5buSTAboiikFPpvQY