### PR TITLE
feat: autonomous version management for agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ This marker is parsed by the agent runner. Always include all fields:
 | `next_steps` | Oak-voice description of what to do next cycle |
 | `issue_outcomes` | **Required when any issues were accepted this cycle.** Array of outcome objects — one per accepted issue. See below. |
 | `version_bump` | **Optional.** Set to `"major"` or `"minor"` to advance the game version. Omit for routine patch releases. See below. |
+| `release_stage` | **Optional.** Override the release stage name shown in the GitHub release title (e.g. `"Alpha"`, `"Beta"`, `"Demo"`, `"Chapter 1 Complete"`). Persists until changed. See below. |
 
 ### version_bump — Autonomous Version Management
 
@@ -160,11 +161,32 @@ You control when the game version advances beyond the current `major.minor`. The
 **How it works:**
 - `"major"` increments `major` and resets `minor` to `0` (e.g. `v0.3.42` → `v1.0.43`)
 - `"minor"` increments `minor`, keeping `major` unchanged (e.g. `v0.3.42` → `v0.4.43`)
-- The release stage advances automatically: Alpha when `major === 0`, Beta when `major >= 1 && minor < 5`, Stable otherwise
+- The default auto-computed stage is: Alpha when `major === 0`, Beta when `major >= 1 && minor < 5`, Stable otherwise — but `release_stage` overrides this
 
 **Example — bumping minor after completing an encounter overhaul:**
 ```json
 {"summary": "...", "changes": [...], "next_steps": "...", "version_bump": "minor"}
+```
+
+### release_stage — Release Stage Name
+
+The release stage appears in the GitHub release title (e.g. `Legends of Hoenn v0.2.47 Beta`). By default it auto-computes from the version numbers, but you can override it to reflect the game's actual development state.
+
+**When to use:**
+- You reach a named milestone that doesn't map neatly to a numeric bump (e.g. `"Demo"`, `"Chapter 1 Complete"`, `"Open Beta"`)
+- You want the stage to say something more meaningful than the default `"Alpha"`/`"Beta"`/`"Stable"`
+- Combined with `version_bump` when a milestone deserves both a number and a new name
+
+**Persists** until you set a new value — no need to repeat it every cycle.
+
+**Example — renaming Alpha to Demo for a public release:**
+```json
+{"summary": "...", "changes": [...], "next_steps": "...", "release_stage": "Demo"}
+```
+
+**Example — combining a version bump with a new stage name:**
+```json
+{"summary": "...", "changes": [...], "next_steps": "...", "version_bump": "minor", "release_stage": "Beta"}
 ```
 
 ### issue_outcomes — Reporting Issue Delivery

--- a/src/agent/output-parser.ts
+++ b/src/agent/output-parser.ts
@@ -43,6 +43,12 @@ export interface ClaudeCodeResult {
    * Omitted: no change to major/minor (normal patch release).
    */
   versionBump?: "major" | "minor";
+  /**
+   * Optional release stage label declared by the agent in the CYCLE_COMPLETE marker.
+   * When set, overrides the auto-computed stage in the GitHub release name.
+   * Examples: "Alpha", "Beta", "Demo", "Stable", "Chapter 1"
+   */
+  releaseStage?: string;
   tokenUsage: { inputTokens: number; outputTokens: number; totalTokens: number };
   toolCallCount: number;
   /** The text from the final "result" message (e.g. structured JSON from --json-schema) */
@@ -70,6 +76,7 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
   let nextSteps = "";
   let issueOutcomes: IssueOutcome[] = [];
   let versionBump: "major" | "minor" | undefined;
+  let releaseStage: string | undefined;
   let toolCallCount = 0;
   let cycleMarkerFound = false;
   const preMarkerTexts: string[] = [];
@@ -131,6 +138,7 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
               next_steps?: string;
               issue_outcomes?: IssueOutcome[];
               version_bump?: string;
+              release_stage?: string;
             };
             cycleSummary = parsed.summary ?? cycleSummary;
             if (Array.isArray(parsed.changes) && parsed.changes.length > 0) {
@@ -148,6 +156,9 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
             }
             if (parsed.version_bump === "major" || parsed.version_bump === "minor") {
               versionBump = parsed.version_bump;
+            }
+            if (typeof parsed.release_stage === "string" && parsed.release_stage.trim()) {
+              releaseStage = parsed.release_stage.trim();
             }
           } catch {
             // Malformed JSON in marker — ignore
@@ -255,6 +266,7 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
     nextSteps,
     issueOutcomes,
     versionBump,
+    releaseStage,
     tokenUsage: {
       inputTokens: totalInputTokens,
       outputTokens: totalOutputTokens,

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -14,7 +14,7 @@ import type { ClaudeCodeResult } from "../agent/output-parser.js";
 import type { ActionRecord } from "../agent/output-parser.js";
 import { runReflection } from "../reflection/reflect.js";
 import { runBuild, saveBuildLog } from "../repo/build.js";
-import { recordSuccessfulBuild, formatVersion, loadVersion, applyVersionBump } from "../repo/version.js";
+import { recordSuccessfulBuild, formatVersion, loadVersion, applyVersionBump, setReleaseStage } from "../repo/version.js";
 import { writeJournalEntry, getNextCycleNumber, getRecentJournalSummaries } from "../journal/writer.js";
 import {
   commitCycle,
@@ -639,10 +639,13 @@ export async function runCycle(): Promise<void> {
     // Create GitHub release with IPS patch if build succeeded with pokeemerald changes
     let releaseUrl: string | null = null;
     if (gameVersion && commitHash && !reverted) {
-      // Apply agent-declared version bump before creating the release tag
+      // Apply agent-declared version bump / release stage before creating the release tag
       if (implResult.versionBump) {
         log.info(`Phase 5: Applying version bump (${implResult.versionBump}) declared by agent...`);
-        applyVersionBump(implResult.versionBump);
+        applyVersionBump(implResult.versionBump, implResult.releaseStage);
+      } else if (implResult.releaseStage) {
+        log.info(`Phase 5: Setting release stage to "${implResult.releaseStage}" declared by agent...`);
+        setReleaseStage(implResult.releaseStage);
       }
 
       log.info("Phase 5: Creating GitHub release with IPS patch...");

--- a/src/release/release.ts
+++ b/src/release/release.ts
@@ -15,10 +15,12 @@ import { formatVersion } from "../repo/version.js";
 import { logger } from "../utils/logger.js";
 
 /**
- * Determine the release stage label based on the version.
- * major === 0: Alpha; minor < 5 when major >= 1: Beta; otherwise Stable.
+ * Determine the release stage label.
+ * Uses the agent-declared stage from version.releaseStage when set;
+ * otherwise auto-computes: major === 0 → Alpha, minor < 5 → Beta, else Stable.
  */
 function getReleaseStage(version: GameVersion): string {
+  if (version.releaseStage) return version.releaseStage;
   if (version.major === 0) return "Alpha";
   if (version.minor < 5) return "Beta";
   return "Stable";

--- a/src/repo/version.ts
+++ b/src/repo/version.ts
@@ -18,6 +18,11 @@ export interface GameVersion {
   cycle: number;
   /** ISO timestamp of the last successful build */
   builtAt: string;
+  /**
+   * Optional release stage label declared by the agent (e.g. "Alpha", "Beta", "Stable").
+   * When set, this overrides the auto-computed stage in release names.
+   */
+  releaseStage?: string;
 }
 
 /** Default initial version for a fresh project */
@@ -65,14 +70,15 @@ export function recordSuccessfulBuild(cycleNumber: number): GameVersion {
 }
 
 /**
- * Apply a major or minor version bump declared by the agent.
+ * Apply a major or minor version bump declared by the agent, and optionally
+ * set a release stage label at the same time.
  * - "major": increment major, reset minor to 0.
  * - "minor": increment minor, keep major unchanged.
  *
  * Call this after recordSuccessfulBuild, once the agent's CYCLE_COMPLETE
  * marker has been parsed and a version bump has been declared.
  */
-export function applyVersionBump(bump: "major" | "minor"): GameVersion {
+export function applyVersionBump(bump: "major" | "minor", releaseStage?: string): GameVersion {
   const version = loadVersion();
 
   if (bump === "major") {
@@ -82,9 +88,28 @@ export function applyVersionBump(bump: "major" | "minor"): GameVersion {
     version.minor += 1;
   }
 
+  if (releaseStage) {
+    version.releaseStage = releaseStage;
+  }
+
   fs.mkdirSync(ARTIFACTS_DIR, { recursive: true });
   fs.writeFileSync(VERSION_FILE, JSON.stringify(version, null, 2) + "\n", "utf-8");
 
-  logger.info(`Version bump (${bump}): ${formatVersion(version)}`);
+  logger.info(`Version bump (${bump}): ${formatVersion(version)}${releaseStage ? ` [${releaseStage}]` : ""}`);
+  return version;
+}
+
+/**
+ * Set the release stage label without changing the version numbers.
+ * Use when the agent declares a stage name but no numeric bump.
+ */
+export function setReleaseStage(releaseStage: string): GameVersion {
+  const version = loadVersion();
+  version.releaseStage = releaseStage;
+
+  fs.mkdirSync(ARTIFACTS_DIR, { recursive: true });
+  fs.writeFileSync(VERSION_FILE, JSON.stringify(version, null, 2) + "\n", "utf-8");
+
+  logger.info(`Release stage set to: ${releaseStage}`);
   return version;
 }


### PR DESCRIPTION
Agent Oak can now declare version bumps in its CYCLE_COMPLETE marker via an optional `version_bump` field ("major" or "minor"). The runner applies the bump to version.json before creating the GitHub release tag, allowing the agent to advance beyond v0.0.x when it reaches milestones.

- output-parser.ts: parse `version_bump` from CYCLE_COMPLETE marker
- version.ts: add `applyVersionBump()` function
- runner.ts: call applyVersionBump() before release creation when declared
- CLAUDE.md: document the new field with when/how guidance for the agent

https://claude.ai/code/session_01JG6b9FLJ95NkJZJh9QQqD7