### PR TITLE
Fix minor version not persisting across cycles

### DIFF
--- a/artifacts/version.json
+++ b/artifacts/version.json
@@ -1,6 +1,6 @@
 {
   "major": 0,
-  "minor": 0,
+  "minor": 1,
   "patch": 43,
   "build": 1,
   "cycle": 43,

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -531,6 +531,19 @@ export async function runCycle(): Promise<void> {
       helpRequests: plan.helpRequests.length > 0 ? plan.helpRequests : undefined,
     });
 
+    // Apply agent-declared version bump / release stage before committing
+    // so that the updated version.json is included in the commit and persists
+    // across cycles (fixes minor version being lost after a bump).
+    if (gameVersion && !reverted) {
+      if (implResult.versionBump) {
+        log.info(`Phase 5: Applying version bump (${implResult.versionBump}) declared by agent...`);
+        applyVersionBump(implResult.versionBump, implResult.releaseStage);
+      } else if (implResult.releaseStage) {
+        log.info(`Phase 5: Setting release stage to "${implResult.releaseStage}" declared by agent...`);
+        setReleaseStage(implResult.releaseStage);
+      }
+    }
+
     log.info("Phase 5: Committing to git...");
     const acceptedIssueNumbers = plan.issueActions
       .filter(a => a.action === "accept")
@@ -636,15 +649,6 @@ export async function runCycle(): Promise<void> {
     // Create GitHub release with IPS patch if build succeeded with pokeemerald changes
     let releaseUrl: string | null = null;
     if (gameVersion && commitHash && !reverted) {
-      // Apply agent-declared version bump / release stage before creating the release tag
-      if (implResult.versionBump) {
-        log.info(`Phase 5: Applying version bump (${implResult.versionBump}) declared by agent...`);
-        applyVersionBump(implResult.versionBump, implResult.releaseStage);
-      } else if (implResult.releaseStage) {
-        log.info(`Phase 5: Setting release stage to "${implResult.releaseStage}" declared by agent...`);
-        setReleaseStage(implResult.releaseStage);
-      }
-
       log.info("Phase 5: Creating GitHub release with IPS patch...");
       const version = loadVersion();
       releaseUrl = await createCycleRelease(


### PR DESCRIPTION
Move version bump (applyVersionBump/setReleaseStage) to run before the git commit instead of after it. Previously, the bumped version.json was written to disk after the commit, so the committed file still had the old minor value. Next cycle would load the committed state, losing the bump entirely.

Also restore version.json minor to 1, which was bumped at cycle 42 but never committed due to this bug.

https://claude.ai/code/session_01Y4C1b3KThMXYDsvw6Gbs8e