### PR TITLE
Fix missing styles in static export by adding basePath for GitHub Pages

### DIFF
--- a/.github/workflows/agent-cycle.yml
+++ b/.github/workflows/agent-cycle.yml
@@ -150,7 +150,7 @@ jobs:
         run: cd docs && npm i
 
       - name: Build docs site
-        run: cd docs && npm run build
+        run: cd docs && NEXT_PUBLIC_BASE_PATH=/agentoak npm run build
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
The site is served from alvarodms.github.io/agentoak/, so all asset paths (CSS, JS) need the /agentoak prefix. Added basePath via NEXT_PUBLIC_BASE_PATH env var, set in the CI/CD build step.

https://claude.ai/code/session_01NeHMzbET8RqHWviscCKKyR