### PR TITLE
Parallelize Gameplay Designer with chunked sub-agents

### DIFF
--- a/src/agent/prompt-sections.ts
+++ b/src/agent/prompt-sections.ts
@@ -123,6 +123,13 @@ You have access to a **Gameplay Designer** agent that can produce detailed, data
 
 **When you set a brief**: Your \`implementationPlan\` should focus on **implementation steps** (which files to modify, data format patterns, how to verify) rather than specifying exact gameplay values. The Gameplay Designer will provide the specific teams, encounters, and values.
 
+**For large tasks** (4+ trainers, multiple routes, full gym rematches, etc.): Use \`gameplayDesignChunks\` instead of \`gameplayDesignBrief\`. This splits the work across 2-4 parallel designer agents, dramatically reducing design time. Each chunk gets its own agent running concurrently.
+
+**How to chunk**: Each chunk must be self-contained — include all context the designer needs (game progression point, difficulty intent, thematic constraints). The designer for one chunk won't see other chunks' output.
+- Example: "Redesign 8 gym leader rematches" → \`gameplayDesignChunks\`: [{label: "Gyms 1-3 Rematches", brief: "..."}, {label: "Gyms 4-6 Rematches", brief: "..."}, {label: "Gyms 7-8 + Champion Rematches", brief: "..."}]
+- Example: "Wild encounters for Routes 110-120" → \`gameplayDesignChunks\`: [{label: "Routes 110-113", brief: "..."}, {label: "Routes 114-117", brief: "..."}, {label: "Routes 118-120", brief: "..."}]
+- Keep chunks to 2-4 (max 4). Group related design units so each chunk has enough context.
+
 **When NOT to use it**: Research cycles, planning cycles, repairs, refactors, pure narrative/dialogue work, or any cycle that doesn't involve gameplay balancing decisions. Skip it to avoid unnecessary latency.`;
 }
 
@@ -134,7 +141,7 @@ export function formatPlannerClosingInstructions(): string {
 
 You may also include \`helpRequests\` if you are stuck on something and want to ask the community for help.
 
-Respond with a **single** JSON object containing mode, objective, reasoning, implementationPlan, and optionally gameplayDesignBrief, issueActions, and helpRequests. All fields must be in one JSON object — do NOT output multiple responses.`;
+Respond with a **single** JSON object containing mode, objective, reasoning, implementationPlan, and optionally gameplayDesignBrief or gameplayDesignChunks (not both), issueActions, and helpRequests. All fields must be in one JSON object — do NOT output multiple responses.`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cycle/gameplay-designer.ts
+++ b/src/cycle/gameplay-designer.ts
@@ -4,7 +4,8 @@
  * using the Pokédex MCP tools.
  *
  * Runs as Phase 1.5 between Planning and Implementation, only when the
- * Producer signals gameplay design is needed via `gameplayDesignBrief`.
+ * Producer signals gameplay design is needed via `gameplayDesignBrief`
+ * or `gameplayDesignChunks` (parallel).
  */
 
 import { runClaudeCode } from "../agent/claude-cli.js";
@@ -23,6 +24,11 @@ export interface GameplayDesignResult {
 
 const GAMEPLAY_DESIGNER_MAX_TURNS = 75;
 const GAMEPLAY_DESIGNER_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes
+
+// Per-chunk limits for parallel designers (smaller scope per agent)
+const CHUNK_DESIGNER_MAX_TURNS = 40;
+const CHUNK_DESIGNER_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_PARALLEL_CHUNKS = 4;
 
 /**
  * Run the Gameplay Designer agent to produce detailed gameplay specs.
@@ -65,6 +71,118 @@ export async function runGameplayDesigner(
     toolCallCount: result.toolCallCount,
     tokenUsage: result.tokenUsage,
   };
+}
+
+/**
+ * Run multiple Gameplay Designer agents in parallel, one per chunk.
+ *
+ * Each chunk gets its own agent with reduced turn/timeout limits.
+ * Results are merged by concatenating specs with chunk labels as headers.
+ * If some chunks fail, successful results are still returned.
+ * If ALL chunks fail, an error is thrown (caller falls back to Producer's plan).
+ */
+export async function runGameplayDesignerParallel(
+  objective: string,
+  chunks: Array<{ label: string; brief: string }>,
+  implementationPlan: string,
+): Promise<GameplayDesignResult> {
+  // Cap the number of parallel agents
+  const activeChunks = chunks.slice(0, MAX_PARALLEL_CHUNKS);
+  if (chunks.length > MAX_PARALLEL_CHUNKS) {
+    logger.warn(
+      `[Gameplay Designer] ${chunks.length} chunks provided, capping at ${MAX_PARALLEL_CHUNKS}`,
+    );
+  }
+
+  logger.info(
+    `[Gameplay Designer] Starting parallel design: ${activeChunks.length} chunks`,
+  );
+  for (const chunk of activeChunks) {
+    logger.info(`  - ${chunk.label}: ${chunk.brief.slice(0, 100)}...`);
+  }
+
+  // Run all chunk designers in parallel
+  const results = await Promise.all(
+    activeChunks.map((chunk) => runChunkDesigner(objective, chunk, implementationPlan)),
+  );
+
+  // Merge results
+  const specParts: string[] = [];
+  let totalToolCalls = 0;
+  let successCount = 0;
+  const mergedTokenUsage: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    const chunk = activeChunks[i];
+    mergedTokenUsage.inputTokens += result.tokenUsage.inputTokens;
+    mergedTokenUsage.outputTokens += result.tokenUsage.outputTokens;
+    mergedTokenUsage.totalTokens += result.tokenUsage.totalTokens;
+    totalToolCalls += result.toolCallCount;
+
+    if (result.specs.trim()) {
+      specParts.push(`## ${chunk.label}\n\n${result.specs}`);
+      successCount++;
+    } else {
+      specParts.push(`## ${chunk.label}\n\n(Designer produced no output for this chunk — implementation agent should use its own judgment for this section.)`);
+    }
+  }
+
+  if (successCount === 0) {
+    throw new Error("All parallel Gameplay Designers produced no output");
+  }
+
+  const mergedSpecs = specParts.join("\n\n---\n\n");
+
+  logger.info(
+    `[Gameplay Designer] Parallel design complete: ${successCount}/${activeChunks.length} chunks successful, ${totalToolCalls} total tool calls, ${mergedSpecs.length} chars`,
+  );
+
+  return {
+    specs: mergedSpecs,
+    toolCallCount: totalToolCalls,
+    tokenUsage: mergedTokenUsage,
+  };
+}
+
+/** Run a single chunk designer agent. Returns empty specs on failure instead of throwing. */
+async function runChunkDesigner(
+  objective: string,
+  chunk: { label: string; brief: string },
+  implementationPlan: string,
+): Promise<GameplayDesignResult> {
+  const emptyResult: GameplayDesignResult = {
+    specs: "",
+    toolCallCount: 0,
+    tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+  };
+
+  try {
+    logger.info(`[Gameplay Designer] Starting chunk: ${chunk.label}`);
+    const prompt = buildGameplayDesignerPrompt(objective, chunk.brief, implementationPlan);
+
+    const result = await runClaudeCode(prompt, {
+      maxTurns: CHUNK_DESIGNER_MAX_TURNS,
+      timeout: CHUNK_DESIGNER_TIMEOUT_MS,
+      tools: "Read",
+      model: process.env.ANTHROPIC_MODEL,
+    });
+
+    const specs = result.narrativeText || result.resultText || "";
+    logger.info(
+      `[Gameplay Designer] Chunk "${chunk.label}" complete: ${result.toolCallCount} tool calls, ${specs.length} chars`,
+    );
+
+    return {
+      specs,
+      toolCallCount: result.toolCallCount,
+      tokenUsage: result.tokenUsage,
+    };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    logger.warn(`[Gameplay Designer] Chunk "${chunk.label}" failed: ${errMsg}`);
+    return emptyResult;
+  }
 }
 
 function buildGameplayDesignerPrompt(

--- a/src/cycle/planner.ts
+++ b/src/cycle/planner.ts
@@ -21,6 +21,8 @@ export interface CyclePlan {
   implementationPlan: string;
   /** Optional brief for the Gameplay Designer agent. When set, Phase 1.5 spawns a specialist to produce detailed gameplay specs. */
   gameplayDesignBrief?: string;
+  /** Optional chunked briefs for parallel Gameplay Designers. When set, multiple designer agents run concurrently. Takes precedence over gameplayDesignBrief. */
+  gameplayDesignChunks?: Array<{ label: string; brief: string }>;
   issueActions: IssueAction[];
   helpRequests: HelpRequest[];
 }
@@ -49,6 +51,19 @@ export const CYCLE_PLAN_SCHEMA: Record<string, unknown> = {
     gameplayDesignBrief: {
       type: "string",
       description: "Optional brief for the Gameplay Designer agent. Set this when the cycle involves gameplay changes (trainer teams, wild encounters, difficulty tuning, etc.). The Gameplay Designer has access to Pokédex MCP tools and will produce detailed, data-driven specifications. When you set this, your implementationPlan should focus on implementation steps (which files to modify, patterns to follow) rather than exact gameplay values — the Gameplay Designer will provide those.",
+    },
+    gameplayDesignChunks: {
+      type: "array",
+      description: "For large design tasks, split the work into independent chunks that run as parallel designer agents. Use INSTEAD of gameplayDesignBrief when the task involves 4+ independent design units (e.g., 8 gym leader rematches → 2-4 chunks). Each chunk gets its own designer agent running concurrently, dramatically reducing wall-clock time.",
+      items: {
+        type: "object",
+        properties: {
+          label: { type: "string", description: "Short label for this chunk (e.g., 'Gyms 1-3 Rematches')" },
+          brief: { type: "string", description: "Self-contained design brief for this chunk. Include all context the designer needs — it won't see other chunks." },
+        },
+        required: ["label", "brief"],
+        additionalProperties: false,
+      },
     },
     issueActions: {
       type: "array",
@@ -104,6 +119,7 @@ export function parsePlanResult(result: ClaudeCodeResult): CyclePlan {
     reasoning?: string;
     implementationPlan?: string;
     gameplayDesignBrief?: string;
+    gameplayDesignChunks?: Array<{ label: string; brief: string }>;
     issueActions?: IssueAction[];
     helpRequests?: HelpRequest[];
   }
@@ -174,6 +190,9 @@ export function parsePlanResult(result: ClaudeCodeResult): CyclePlan {
       reasoning: parsed.reasoning,
       implementationPlan: parsed.implementationPlan ?? "",
       gameplayDesignBrief: parsed.gameplayDesignBrief || undefined,
+      gameplayDesignChunks: Array.isArray(parsed.gameplayDesignChunks) && parsed.gameplayDesignChunks.length > 0
+        ? parsed.gameplayDesignChunks
+        : undefined,
       issueActions,
       helpRequests,
     };

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { loadMemory, updateCycleModeHistory } from "../memory/store.js";
 import { planCycle } from "./planner.js";
 import type { CyclePlan } from "./planner.js";
-import { runGameplayDesigner } from "./gameplay-designer.js";
+import { runGameplayDesigner, runGameplayDesignerParallel } from "./gameplay-designer.js";
 import { getModeDescription, isCodingMode } from "./modes.js";
 import {
   buildDynamicContext,
@@ -443,7 +443,25 @@ export async function runCycle(): Promise<void> {
     let activePlan: CyclePlan = plan;
     let gameplayDesignTokenUsage: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
 
-    if (plan.gameplayDesignBrief) {
+    if (plan.gameplayDesignChunks?.length) {
+      log.info(`Phase 1.5: Gameplay Design (parallel — ${plan.gameplayDesignChunks.length} chunks)...`);
+      try {
+        const designResult = await runGameplayDesignerParallel(
+          plan.objective,
+          plan.gameplayDesignChunks,
+          plan.implementationPlan,
+        );
+        activePlan = {
+          ...plan,
+          implementationPlan: `${plan.implementationPlan}\n\n## Gameplay Specifications (from Gameplay Designer)\n\n${designResult.specs}`,
+        };
+        gameplayDesignTokenUsage = designResult.tokenUsage;
+        log.info(`  Gameplay design complete: ${designResult.toolCallCount} tool calls, ${designResult.specs.length} chars`);
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log.warn(`  Parallel Gameplay Designer failed, proceeding with Producer's plan: ${errMsg}`);
+      }
+    } else if (plan.gameplayDesignBrief) {
       log.info("Phase 1.5: Gameplay Design...");
       try {
         const designResult = await runGameplayDesigner(


### PR DESCRIPTION
When the planner identifies a large design task (4+ trainers, multiple routes, etc.), it can now split the work into independent chunks via the new `gameplayDesignChunks` field. Each chunk spawns its own designer agent running concurrently via Promise.all(), dramatically reducing wall-clock time for large design tasks.

- Add `gameplayDesignChunks` to CyclePlan interface and JSON schema
- Add `runGameplayDesignerParallel()` using same pattern as team-planner
- Per-chunk limits: 40 turns, 10 min timeout (vs 75/15 for single)
- Cap at 4 parallel chunks; partial failures don't block other chunks
- Update planner prompt guidance with chunking examples
- Fully backwards compatible: single `gameplayDesignBrief` path unchanged

https://claude.ai/code/session_018BALYb5gvrGkW9J55bDWrY