### PR TITLE
Enhance docs website: pagination, progression-based guide, new specie…

### DIFF
--- a/docs/src/components/RouteCard.tsx
+++ b/docs/src/components/RouteCard.tsx
@@ -6,6 +6,8 @@ import type { RouteData, EncounterEntry } from '../lib/types';
 interface RouteCardProps {
   name: string;
   route: RouteData;
+  /** Species appearing for the first time in game progression */
+  newSpecies?: Set<string>;
 }
 
 interface DeduplicatedEncounter extends EncounterEntry {
@@ -28,7 +30,15 @@ function deduplicateEncounters(mons: EncounterEntry[]): DeduplicatedEncounter[] 
   return [...seen.values()].sort((a, b) => b.totalRate - a.totalRate);
 }
 
-function EncounterTable({ title, mons }: { title: string; mons: EncounterEntry[] }) {
+function EncounterTable({
+  title,
+  mons,
+  newSpecies,
+}: {
+  title: string;
+  mons: EncounterEntry[];
+  newSpecies?: Set<string>;
+}) {
   const deduped = deduplicateEncounters(mons);
 
   return (
@@ -49,6 +59,9 @@ function EncounterTable({ title, mons }: { title: string; mons: EncounterEntry[]
               <td className="mon-name">
                 <PokemonSprite name={m.species} className="pokemon-thumb-sm" />
                 {m.species}
+                {newSpecies?.has(m.species) && (
+                  <span className="new-species-badge">NEW</span>
+                )}
               </td>
               <td>{m.minLevel === m.maxLevel ? m.minLevel : `${m.minLevel}\u2013${m.maxLevel}`}</td>
               <td>{m.totalRate}%</td>
@@ -65,7 +78,7 @@ function EncounterTable({ title, mons }: { title: string; mons: EncounterEntry[]
   );
 }
 
-export default function RouteCard({ name, route }: RouteCardProps) {
+export default function RouteCard({ name, route, newSpecies }: RouteCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   const allSpecies = new Set<string>();
@@ -81,21 +94,26 @@ export default function RouteCard({ name, route }: RouteCardProps) {
     });
   }
 
+  const newCount = newSpecies ? [...allSpecies].filter(s => newSpecies.has(s)).length : 0;
+
   return (
     <div className={`guide-card${expanded ? ' expanded' : ''}`}>
       <div className="guide-card-header" onClick={() => setExpanded(!expanded)}>
         <span className="guide-card-title">{name}</span>
         <span className="encounter-count">{allSpecies.size} species</span>
+        {newCount > 0 && (
+          <span className="new-count-badge">{newCount} new</span>
+        )}
         <span className="card-expand">{'\u25BC'}</span>
       </div>
 
       <div className="guide-card-body">
-        {route.land && <EncounterTable title="&#x1F33F; Grass / Cave" mons={route.land} />}
-        {route.water && <EncounterTable title="&#x1F30A; Surfing" mons={route.water} />}
-        {route.rockSmash && <EncounterTable title="&#x1FAA8; Rock Smash" mons={route.rockSmash} />}
-        {route.fishing?.oldRod && <EncounterTable title="&#x1F3A3; Old Rod" mons={route.fishing.oldRod} />}
-        {route.fishing?.goodRod && <EncounterTable title="&#x1F3A3; Good Rod" mons={route.fishing.goodRod} />}
-        {route.fishing?.superRod && <EncounterTable title="&#x1F3A3; Super Rod" mons={route.fishing.superRod} />}
+        {route.land && <EncounterTable title="&#x1F33F; Grass / Cave" mons={route.land} newSpecies={newSpecies} />}
+        {route.water && <EncounterTable title="&#x1F30A; Surfing" mons={route.water} newSpecies={newSpecies} />}
+        {route.rockSmash && <EncounterTable title="&#x1FAA8; Rock Smash" mons={route.rockSmash} newSpecies={newSpecies} />}
+        {route.fishing?.oldRod && <EncounterTable title="&#x1F3A3; Old Rod" mons={route.fishing.oldRod} newSpecies={newSpecies} />}
+        {route.fishing?.goodRod && <EncounterTable title="&#x1F3A3; Good Rod" mons={route.fishing.goodRod} newSpecies={newSpecies} />}
+        {route.fishing?.superRod && <EncounterTable title="&#x1F3A3; Super Rod" mons={route.fishing.superRod} newSpecies={newSpecies} />}
       </div>
     </div>
   );

--- a/docs/src/lib/game-progression.ts
+++ b/docs/src/lib/game-progression.ts
@@ -1,0 +1,129 @@
+/**
+ * Pokémon Emerald game progression — defines the order locations, battles,
+ * and events occur as a player progresses through the main story.
+ */
+
+export interface ProgressionStep {
+  type: 'starter' | 'route' | 'gym' | 'rival' | 'elite-four' | 'champion' | 'landmark' | 'chapter';
+  label: string;
+  /** Matches key in GuideData.routes (e.g. "Route 101", "Petalburg Woods") */
+  routeKeys?: string[];
+  /** Matches gymLeader.gym number */
+  gymNumber?: number;
+  /** Substring match against rival battle location */
+  rivalLocation?: string;
+  /** Flavor text for landmarks / chapters */
+  description?: string;
+}
+
+export const GAME_PROGRESSION: ProgressionStep[] = [
+  // ── Chapter 1: The Journey Begins ──
+  { type: 'chapter', label: 'Chapter 1: The Journey Begins', description: 'Choose your partner and take your first steps into Hoenn.' },
+  { type: 'starter', label: 'Starter Selection' },
+  { type: 'route', label: 'Route 101', routeKeys: ['Route 101'] },
+  { type: 'landmark', label: 'Oldale Town', description: 'A small town with a Pok\u00e9mon Center and Pok\u00e9 Mart.' },
+  { type: 'route', label: 'Route 103', routeKeys: ['Route 103'] },
+  { type: 'rival', label: 'Rival Battle \u2014 Route 103', rivalLocation: 'Route 103' },
+  { type: 'route', label: 'Route 102', routeKeys: ['Route 102'] },
+
+  // ── Chapter 2: First Gym Challenge ──
+  { type: 'chapter', label: 'Chapter 2: First Gym Challenge', description: 'Head through Petalburg Woods to reach Rustboro City and face Roxanne.' },
+  { type: 'landmark', label: 'Petalburg City', description: 'Your father Norman\'s gym is here, but you need 4 badges first.' },
+  { type: 'route', label: 'Route 104', routeKeys: ['Route 104'] },
+  { type: 'route', label: 'Petalburg Woods', routeKeys: ['Petalburg Woods'] },
+  { type: 'landmark', label: 'Rustboro City', description: 'Home to the Rustboro Gym and Devon Corporation.' },
+  { type: 'gym', label: 'Gym 1: Roxanne', gymNumber: 1 },
+  { type: 'route', label: 'Route 116', routeKeys: ['Route 116'] },
+  { type: 'route', label: 'Rusturf Tunnel', routeKeys: ['Rusturf Tunnel'] },
+
+  // ── Chapter 3: Island Detour ──
+  { type: 'chapter', label: 'Chapter 3: Island Detour', description: 'Sail to Dewford Town and explore the seas south of Hoenn.' },
+  { type: 'route', label: 'Route 104 (South)', routeKeys: ['Route 104'] },
+  { type: 'route', label: 'Sea Routes 105\u2013109', routeKeys: ['Route 105', 'Route 106', 'Route 107', 'Route 108', 'Route 109'] },
+  { type: 'route', label: 'Granite Cave', routeKeys: ['Granite Cave 1f', 'Granite Cave B1f', 'Granite Cave B2f', 'Granite Cave Stevens Room'] },
+  { type: 'landmark', label: 'Dewford Town', description: 'A small island town known for its trendy sayings.' },
+  { type: 'gym', label: 'Gym 2: Brawly', gymNumber: 2 },
+
+  // ── Chapter 4: The Electric Road ──
+  { type: 'chapter', label: 'Chapter 4: The Electric Road', description: 'Travel north to Mauville City and face Wattson.' },
+  { type: 'landmark', label: 'Slateport City', description: 'A bustling port city with a market and museum.' },
+  { type: 'route', label: 'Route 110', routeKeys: ['Route 110'] },
+  { type: 'rival', label: 'Rival Battle \u2014 Route 110', rivalLocation: 'Route 110' },
+  { type: 'landmark', label: 'Mauville City', description: 'The crossroads of Hoenn, home to the Game Corner and Bike Shop.' },
+  { type: 'gym', label: 'Gym 3: Wattson', gymNumber: 3 },
+  { type: 'route', label: 'New Mauville', routeKeys: ['New Mauville Entrance', 'New Mauville Inside'] },
+
+  // ── Chapter 5: The Road to Lavaridge ──
+  { type: 'chapter', label: 'Chapter 5: The Road to Lavaridge', description: 'Journey through the volcanic routes to reach Lavaridge Town.' },
+  { type: 'route', label: 'Route 117', routeKeys: ['Route 117'] },
+  { type: 'route', label: 'Route 111 (North)', routeKeys: ['Route 111'] },
+  { type: 'route', label: 'Route 112', routeKeys: ['Route 112'] },
+  { type: 'route', label: 'Fiery Path', routeKeys: ['Fiery Path'] },
+  { type: 'route', label: 'Route 113', routeKeys: ['Route 113'] },
+  { type: 'landmark', label: 'Fallarbor Town', description: 'A quiet town near the foot of Mt. Chimney.' },
+  { type: 'route', label: 'Route 114', routeKeys: ['Route 114'] },
+  { type: 'route', label: 'Meteor Falls', routeKeys: ['Meteor Falls 1f 1r', 'Meteor Falls 1f 2r'] },
+  { type: 'route', label: 'Jagged Pass', routeKeys: ['Jagged Pass'] },
+  { type: 'landmark', label: 'Lavaridge Town', description: 'A town famous for its hot springs, nestled at the base of Mt. Chimney.' },
+  { type: 'gym', label: 'Gym 4: Flannery', gymNumber: 4 },
+
+  // ── Chapter 6: Norman's Challenge ──
+  { type: 'chapter', label: 'Chapter 6: Norman\'s Challenge', description: 'Return to Petalburg to challenge your father.' },
+  { type: 'route', label: 'Route 111 (Desert)', routeKeys: ['Route 111'] },
+  { type: 'route', label: 'Mirage Tower', routeKeys: ['Mirage Tower 1f', 'Mirage Tower 2f', 'Mirage Tower 3f', 'Mirage Tower 4f'] },
+  { type: 'gym', label: 'Gym 5: Norman', gymNumber: 5 },
+
+  // ── Chapter 7: East Hoenn ──
+  { type: 'chapter', label: 'Chapter 7: East Hoenn', description: 'Cross the water to explore eastern Hoenn and earn the Feather Badge.' },
+  { type: 'route', label: 'Route 118', routeKeys: ['Route 118'] },
+  { type: 'route', label: 'Route 119', routeKeys: ['Route 119'] },
+  { type: 'rival', label: 'Rival Battle \u2014 Route 119', rivalLocation: 'Route 119' },
+  { type: 'landmark', label: 'Fortree City', description: 'A city of treehouses deep in the forest.' },
+  { type: 'gym', label: 'Gym 6: Winona', gymNumber: 6 },
+  { type: 'route', label: 'Route 120', routeKeys: ['Route 120'] },
+  { type: 'route', label: 'Route 121', routeKeys: ['Route 121'] },
+  { type: 'route', label: 'Safari Zone', routeKeys: ['Safari Zone North', 'Safari Zone Northeast', 'Safari Zone Northwest', 'Safari Zone South', 'Safari Zone Southeast', 'Safari Zone Southwest'] },
+
+  // ── Chapter 8: Lilycove & Mt. Pyre ──
+  { type: 'chapter', label: 'Chapter 8: Lilycove & Mt. Pyre', description: 'Confront Team Aqua and protect Mt. Pyre.' },
+  { type: 'landmark', label: 'Lilycove City', description: 'The cultural capital of Hoenn, home to the Contest Hall and Department Store.' },
+  { type: 'rival', label: 'Rival Battle \u2014 Lilycove', rivalLocation: 'Lilycove' },
+  { type: 'route', label: 'Route 122', routeKeys: ['Route 122'] },
+  { type: 'route', label: 'Mt. Pyre', routeKeys: ['Mt Pyre 1f', 'Mt Pyre 2f', 'Mt Pyre 3f', 'Mt Pyre 4f', 'Mt Pyre 5f', 'Mt Pyre 6f', 'Mt Pyre Exterior', 'Mt Pyre Summit'] },
+  { type: 'route', label: 'Route 123', routeKeys: ['Route 123'] },
+  { type: 'route', label: 'Magma Hideout', routeKeys: ['Magma Hideout 1f', 'Magma Hideout 2f 1r', 'Magma Hideout 2f 2r', 'Magma Hideout 2f 3r', 'Magma Hideout 3f 1r', 'Magma Hideout 3f 2r', 'Magma Hideout 3f 3r', 'Magma Hideout 4f'] },
+
+  // ── Chapter 9: The Deep Sea ──
+  { type: 'chapter', label: 'Chapter 9: The Deep Sea', description: 'Dive beneath the ocean and earn the Mind Badge on Mossdeep Island.' },
+  { type: 'route', label: 'Sea Routes 124\u2013126', routeKeys: ['Route 124', 'Route 125', 'Route 126'] },
+  { type: 'route', label: 'Shoal Cave', routeKeys: ['Shoal Cave Low Tide Entrance Room', 'Shoal Cave Low Tide Ice Room', 'Shoal Cave Low Tide Inner Room', 'Shoal Cave Low Tide Lower Room', 'Shoal Cave Low Tide Stairs Room'] },
+  { type: 'landmark', label: 'Mossdeep City', description: 'Home to the Space Center and the 7th Gym.' },
+  { type: 'gym', label: 'Gym 7: Tate & Liza', gymNumber: 7 },
+  { type: 'route', label: 'Route 127', routeKeys: ['Route 127'] },
+  { type: 'route', label: 'Seafloor Cavern', routeKeys: ['Seafloor Cavern Entrance', 'Seafloor Cavern Room1', 'Seafloor Cavern Room2', 'Seafloor Cavern Room3', 'Seafloor Cavern Room4', 'Seafloor Cavern Room5', 'Seafloor Cavern Room6', 'Seafloor Cavern Room7', 'Seafloor Cavern Room8'] },
+
+  // ── Chapter 10: The Final Gym ──
+  { type: 'chapter', label: 'Chapter 10: The Final Gym', description: 'Calm Groudon and Kyogre, then earn your 8th badge.' },
+  { type: 'route', label: 'Route 128', routeKeys: ['Route 128'] },
+  { type: 'route', label: 'Cave of Origin', routeKeys: ['Cave Of Origin Entrance', 'Cave Of Origin 1f'] },
+  { type: 'landmark', label: 'Sootopolis City', description: 'A city inside a volcanic crater, accessible only by sea or sky.' },
+  { type: 'gym', label: 'Gym 8: Juan', gymNumber: 8 },
+
+  // ── Chapter 11: Victory Road & the League ──
+  { type: 'chapter', label: 'Chapter 11: Victory Road & the League', description: 'The final stretch — conquer Victory Road and become Champion.' },
+  { type: 'route', label: 'Sea Routes 129\u2013134', routeKeys: ['Route 129', 'Route 130', 'Route 131', 'Route 132', 'Route 133', 'Route 134'] },
+  { type: 'landmark', label: 'Ever Grande City', description: 'The gateway to the Pok\u00e9mon League.' },
+  { type: 'route', label: 'Victory Road', routeKeys: ['Victory Road 1f', 'Victory Road B1f', 'Victory Road B2f'] },
+  { type: 'elite-four', label: 'Elite Four' },
+  { type: 'champion', label: 'Champion' },
+
+  // ── Postgame ──
+  { type: 'chapter', label: 'Postgame', description: 'Explore remaining areas and catch rare Pok\u00e9mon.' },
+  { type: 'route', label: 'Route 115', routeKeys: ['Route 115'] },
+  { type: 'route', label: 'Sky Pillar', routeKeys: ['Sky Pillar 1f', 'Sky Pillar 3f'] },
+  { type: 'route', label: 'Meteor Falls (Deep)', routeKeys: ['Meteor Falls B1f 1r', 'Meteor Falls B1f 2r', 'Meteor Falls Stevens Cave'] },
+  { type: 'route', label: 'Altering Cave', routeKeys: ['Altering Cave'] },
+  { type: 'route', label: 'Artisan Cave', routeKeys: ['Artisan Cave 1f', 'Artisan Cave B1f'] },
+  { type: 'route', label: 'Desert Underpass', routeKeys: ['Desert Underpass'] },
+  { type: 'route', label: 'Abandoned Ship', routeKeys: ['Abandoned Ship Hidden Floor Corridors', 'Abandoned Ship Rooms B1f'] },
+];

--- a/docs/src/pages/GuidePage.tsx
+++ b/docs/src/pages/GuidePage.tsx
@@ -1,23 +1,267 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import PokemonSprite from '../components/PokemonSprite';
 import TrainerCard from '../components/TrainerCard';
 import RouteCard from '../components/RouteCard';
+import TypeBadge from '../components/TypeBadge';
 import { TYPE_EMOJIS } from '../lib/type-utils';
-import type { GuideData } from '../lib/types';
+import { GAME_PROGRESSION } from '../lib/game-progression';
+import type { ProgressionStep } from '../lib/game-progression';
+import type { GuideData, EncounterEntry } from '../lib/types';
 
-function sortRouteNames(names: string[]): string[] {
-  return names.sort((a, b) => {
-    const aNum = a.match(/^Route (\d+)$/);
-    const bNum = b.match(/^Route (\d+)$/);
-    if (aNum && bNum) return parseInt(aNum[1]) - parseInt(bNum[1]);
-    if (aNum) return -1;
-    if (bNum) return 1;
-    return a.localeCompare(b);
-  });
+/** Collect all unique species from a set of route keys. */
+function collectSpecies(data: GuideData, routeKeys: string[]): string[] {
+  const species = new Set<string>();
+  for (const key of routeKeys) {
+    const route = data.routes[key];
+    if (!route) continue;
+    for (const type of ['land', 'water', 'rockSmash'] as const) {
+      const entries = route[type];
+      if (Array.isArray(entries)) {
+        (entries as EncounterEntry[]).forEach(m => species.add(m.species));
+      }
+    }
+    if (route.fishing) {
+      for (const rod of ['oldRod', 'goodRod', 'superRod'] as const) {
+        if (route.fishing[rod]) {
+          route.fishing[rod]!.forEach(m => species.add(m.species));
+        }
+      }
+    }
+  }
+  return [...species];
+}
+
+/** Compute guide-wide stats from the data. */
+function computeStats(data: GuideData) {
+  const allSpecies = new Set<string>();
+  let maxLevel = 0;
+  let minLevel = 999;
+
+  for (const route of Object.values(data.routes)) {
+    for (const type of ['land', 'water', 'rockSmash'] as const) {
+      const entries = route[type];
+      if (Array.isArray(entries)) {
+        (entries as EncounterEntry[]).forEach(m => {
+          allSpecies.add(m.species);
+          if (m.maxLevel > maxLevel) maxLevel = m.maxLevel;
+          if (m.minLevel < minLevel) minLevel = m.minLevel;
+        });
+      }
+    }
+    if (route.fishing) {
+      for (const rod of ['oldRod', 'goodRod', 'superRod'] as const) {
+        if (route.fishing[rod]) {
+          route.fishing[rod]!.forEach(m => {
+            allSpecies.add(m.species);
+            if (m.maxLevel > maxLevel) maxLevel = m.maxLevel;
+            if (m.minLevel < minLevel) minLevel = m.minLevel;
+          });
+        }
+      }
+    }
+  }
+
+  // Check trainer levels too
+  for (const gym of data.gymLeaders) {
+    for (const mon of gym.party) {
+      if (mon.level > maxLevel) maxLevel = mon.level;
+    }
+  }
+  if (data.champion) {
+    for (const mon of data.champion.party) {
+      if (mon.level > maxLevel) maxLevel = mon.level;
+    }
+  }
+
+  return {
+    totalRoutes: Object.keys(data.routes).length,
+    totalSpecies: allSpecies.size,
+    trainers: data.gymLeaders.length + data.eliteFour.length + (data.champion ? 1 : 0),
+    levelRange: `Lv ${minLevel}\u2013${maxLevel}`,
+  };
+}
+
+/** Render a single progression step. */
+function StepRenderer({
+  step,
+  data,
+  newSpecies,
+}: {
+  step: ProgressionStep;
+  data: GuideData;
+  newSpecies: Set<string>;
+}) {
+  switch (step.type) {
+    case 'chapter':
+      return (
+        <div className="progression-chapter" id={step.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}>
+          <h2 className="progression-chapter-title">{step.label}</h2>
+          {step.description && <p className="progression-chapter-desc">{step.description}</p>}
+        </div>
+      );
+
+    case 'starter':
+      return (
+        <div className="info-card">
+          <h3>{'\u2694\uFE0F'} Starter Pok&eacute;mon</h3>
+          <div className="starter-grid">
+            {data.starters.map((s, i) => {
+              const types = s.types || [];
+              const typeStr = types.join(' / ');
+              return (
+                <div key={i} className="starter-card">
+                  <div className="pokemon-sprite-wrap">
+                    <PokemonSprite name={s.species} className="pokemon-sprite-wrap-img" />
+                  </div>
+                  <div className="pokemon-name">{s.species}</div>
+                  <div className="pokemon-type">{typeStr}</div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      );
+
+    case 'route': {
+      if (!step.routeKeys || step.routeKeys.length === 0) return null;
+      // Check if any route key actually has data
+      const validKeys = step.routeKeys.filter(k => data.routes[k]);
+      if (validKeys.length === 0) return null;
+
+      // For multi-floor / multi-area locations, merge into a combined view
+      if (validKeys.length === 1) {
+        return (
+          <RouteCard
+            name={step.label}
+            route={data.routes[validKeys[0]]}
+            newSpecies={newSpecies}
+          />
+        );
+      }
+
+      // Multiple sub-areas — render each
+      return (
+        <div className="route-group">
+          <div className="route-group-label">{step.label}</div>
+          {validKeys.map(key => (
+            <RouteCard
+              key={key}
+              name={key}
+              route={data.routes[key]}
+              newSpecies={newSpecies}
+            />
+          ))}
+        </div>
+      );
+    }
+
+    case 'gym': {
+      const gym = data.gymLeaders.find(g => g.gym === step.gymNumber);
+      if (!gym) return null;
+      return (
+        <TrainerCard
+          title={`Gym ${gym.gym}: ${gym.name}`}
+          subtitle={gym.location + (gym.doubleBattle ? ' \u00B7 Double Battle' : '')}
+          typeBadge={gym.type}
+          party={gym.party}
+        />
+      );
+    }
+
+    case 'rival': {
+      const battles = data.rivals.filter(r => {
+        if (!step.rivalLocation) return false;
+        return r.location.includes(step.rivalLocation);
+      });
+      if (battles.length === 0) return null;
+
+      // Group by rival name, show all starter matchups
+      return (
+        <>
+          {battles
+            .sort((a, b) => {
+              const maxA = Math.max(...a.party.map(p => p.level));
+              const maxB = Math.max(...b.party.map(p => p.level));
+              return maxA - maxB;
+            })
+            .map((battle, i) => (
+              <TrainerCard
+                key={i}
+                title={`${battle.rival} \u2014 ${battle.location}`}
+                subtitle={battle.starterMatchup ? `If player chose: ${battle.starterMatchup}` : ''}
+                typeBadge="Rival"
+                party={battle.party}
+              />
+            ))}
+        </>
+      );
+    }
+
+    case 'elite-four':
+      return (
+        <div className="guide-section">
+          <h3 className="guide-section-title">{'\uD83C\uDFC6'} Elite Four</h3>
+          {data.eliteFour.map((e4, i) => (
+            <TrainerCard
+              key={i}
+              title={`Elite Four #${i + 1}: ${e4.name}`}
+              subtitle={`${e4.type} Specialist`}
+              typeBadge={e4.type}
+              party={e4.party}
+            />
+          ))}
+        </div>
+      );
+
+    case 'champion':
+      if (!data.champion) return null;
+      return (
+        <div className="guide-section">
+          <h3 className="guide-section-title">{'\uD83D\uDC51'} Champion</h3>
+          <TrainerCard
+            title={`Champion ${data.champion.name}`}
+            subtitle="The final challenge"
+            typeBadge="Champion"
+            party={data.champion.party}
+          />
+        </div>
+      );
+
+    case 'landmark':
+      return (
+        <div className="landmark-card">
+          <span className="landmark-icon">{'\uD83C\uDFD8\uFE0F'}</span>
+          <div>
+            <div className="landmark-name">{step.label}</div>
+            {step.description && <div className="landmark-desc">{step.description}</div>}
+          </div>
+        </div>
+      );
+
+    default:
+      return null;
+  }
+}
+
+/** Determine the CSS class for a step type's left border color */
+function stepTypeClass(type: ProgressionStep['type']): string {
+  switch (type) {
+    case 'gym': return 'step-gym';
+    case 'rival': return 'step-rival';
+    case 'route': return 'step-route';
+    case 'elite-four': return 'step-elite';
+    case 'champion': return 'step-champion';
+    case 'starter': return 'step-starter';
+    case 'landmark': return 'step-landmark';
+    case 'chapter': return 'step-chapter';
+    default: return '';
+  }
 }
 
 export default function GuidePage() {
   const [data, setData] = useState<GuideData | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     fetch(import.meta.env.BASE_URL + 'data/game-guide.json')
@@ -25,6 +269,80 @@ export default function GuidePage() {
       .then(setData)
       .catch(() => {});
   }, []);
+
+  // Build the "new species" set: track species seen so far, mark first appearances
+  const newSpeciesByStep = useMemo(() => {
+    if (!data) return new Map<number, Set<string>>();
+    const seen = new Set<string>();
+    const result = new Map<number, Set<string>>();
+
+    for (let i = 0; i < GAME_PROGRESSION.length; i++) {
+      const step = GAME_PROGRESSION[i];
+      if (step.type !== 'route' || !step.routeKeys) continue;
+
+      const stepNew = new Set<string>();
+      const species = collectSpecies(data, step.routeKeys);
+      for (const sp of species) {
+        if (!seen.has(sp)) {
+          stepNew.add(sp);
+          seen.add(sp);
+        }
+      }
+      result.set(i, stepNew);
+    }
+
+    return result;
+  }, [data]);
+
+  // Collect chapter labels for quick nav
+  const chapters = useMemo(() => {
+    return GAME_PROGRESSION
+      .map((step, i) => ({ step, index: i }))
+      .filter(({ step }) => step.type === 'chapter');
+  }, []);
+
+  // Filter steps based on search
+  const filteredSteps = useMemo(() => {
+    if (!searchQuery.trim()) return GAME_PROGRESSION.map((step, i) => ({ step, index: i }));
+
+    const q = searchQuery.toLowerCase();
+    // Keep chapters if any of their children match
+    const matchingIndices = new Set<number>();
+
+    for (let i = 0; i < GAME_PROGRESSION.length; i++) {
+      const step = GAME_PROGRESSION[i];
+      if (step.label.toLowerCase().includes(q)) {
+        matchingIndices.add(i);
+      }
+      // Also match route keys
+      if (step.routeKeys?.some(k => k.toLowerCase().includes(q))) {
+        matchingIndices.add(i);
+      }
+    }
+
+    // Include chapter headers if any following step (before next chapter) matches
+    const result: { step: ProgressionStep; index: number }[] = [];
+    let currentChapterIdx = -1;
+    let chapterAdded = false;
+
+    for (let i = 0; i < GAME_PROGRESSION.length; i++) {
+      const step = GAME_PROGRESSION[i];
+      if (step.type === 'chapter') {
+        currentChapterIdx = i;
+        chapterAdded = false;
+        continue;
+      }
+      if (matchingIndices.has(i)) {
+        if (!chapterAdded && currentChapterIdx >= 0) {
+          result.push({ step: GAME_PROGRESSION[currentChapterIdx], index: currentChapterIdx });
+          chapterAdded = true;
+        }
+        result.push({ step, index: i });
+      }
+    }
+
+    return result;
+  }, [searchQuery]);
 
   if (!data) {
     return (
@@ -34,100 +352,82 @@ export default function GuidePage() {
     );
   }
 
-  const routeNames = sortRouteNames(Object.keys(data.routes));
+  const stats = computeStats(data);
 
   return (
     <section className="guide-view active">
-      {/* Starters */}
-      <div className="info-card">
-        <h3>{'\u2694\uFE0F'} Starter Pok&eacute;mon</h3>
-        <div className="starter-grid">
-          {data.starters.map((s, i) => {
-            const types = s.types || [];
-            const typeStr = types.join(' / ');
-            const emoji = TYPE_EMOJIS[types[0]] || '\uD83D\uDC7E';
-            return (
-              <div key={i} className="starter-card">
-                <div className="pokemon-sprite-wrap">
-                  <PokemonSprite name={s.species} className="pokemon-sprite-wrap-img" />
-                </div>
-                <div className="pokemon-name">{s.species}</div>
-                <div className="pokemon-type">{typeStr}</div>
-              </div>
-            );
-          })}
+      {/* Stats Banner */}
+      <div className="guide-stats-banner">
+        <div className="guide-stat">
+          <div className="guide-stat-value">{stats.totalRoutes}</div>
+          <div className="guide-stat-label">Locations</div>
+        </div>
+        <div className="guide-stat">
+          <div className="guide-stat-value">{stats.totalSpecies}</div>
+          <div className="guide-stat-label">Species</div>
+        </div>
+        <div className="guide-stat">
+          <div className="guide-stat-value">{stats.trainers}</div>
+          <div className="guide-stat-label">Key Trainers</div>
+        </div>
+        <div className="guide-stat">
+          <div className="guide-stat-value">{stats.levelRange}</div>
+          <div className="guide-stat-label">Level Range</div>
         </div>
       </div>
 
-      {/* Gym Leaders */}
-      <div className="guide-section">
-        <h2 className="guide-section-title">{'\uD83C\uDFDF\uFE0F'} Gym Leaders</h2>
-        {data.gymLeaders.map((gym, i) => (
-          <TrainerCard
-            key={i}
-            title={`Gym ${gym.gym}: ${gym.name}`}
-            subtitle={gym.location + (gym.doubleBattle ? ' \u00B7 Double Battle' : '')}
-            typeBadge={gym.type}
-            party={gym.party}
+      {/* Search & Quick Nav */}
+      <div className="guide-toolbar">
+        <div className="guide-search-wrap">
+          <input
+            ref={searchRef}
+            type="text"
+            className="guide-search"
+            placeholder="Search locations, trainers..."
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
           />
+          {searchQuery && (
+            <button className="guide-search-clear" onClick={() => setSearchQuery('')}>
+              {'\u2715'}
+            </button>
+          )}
+        </div>
+        <div className="guide-quick-nav">
+          {chapters.map(({ step, index }) => (
+            <a
+              key={index}
+              className="guide-quick-nav-item"
+              href={`#${step.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}
+              title={step.label}
+            >
+              {step.label.replace(/^Chapter \d+:\s*/, '')}
+            </a>
+          ))}
+        </div>
+      </div>
+
+      {/* Progression Timeline */}
+      <div className="progression-timeline">
+        {filteredSteps.map(({ step, index }) => (
+          <div
+            key={index}
+            className={`progression-step ${stepTypeClass(step.type)}`}
+          >
+            <StepRenderer
+              step={step}
+              data={data}
+              newSpecies={newSpeciesByStep.get(index) || new Set()}
+            />
+          </div>
         ))}
       </div>
 
-      {/* Elite Four */}
-      <div className="guide-section">
-        <h2 className="guide-section-title">{'\uD83C\uDFC6'} Elite Four</h2>
-        {data.eliteFour.map((e4, i) => (
-          <TrainerCard
-            key={i}
-            title={`Elite Four #${i + 1}: ${e4.name}`}
-            subtitle={`${e4.type} Specialist`}
-            typeBadge={e4.type}
-            party={e4.party}
-          />
-        ))}
-      </div>
-
-      {/* Champion */}
-      {data.champion && (
-        <div className="guide-section">
-          <h2 className="guide-section-title">{'\uD83D\uDC51'} Champion</h2>
-          <TrainerCard
-            title={`Champion ${data.champion.name}`}
-            subtitle="The final challenge"
-            typeBadge="Champion"
-            party={data.champion.party}
-          />
+      {searchQuery && filteredSteps.length === 0 && (
+        <div className="info-card">
+          <p>No locations or trainers match &ldquo;{searchQuery}&rdquo;.</p>
         </div>
       )}
-
-      {/* Rivals */}
-      <div className="guide-section">
-        <h2 className="guide-section-title">{'\uD83C\uDFC3'} Rival Battles</h2>
-        {data.rivals
-          .filter(r => r.rival === 'Brendan')
-          .sort((a, b) => {
-            const maxA = Math.max(...a.party.map(p => p.level));
-            const maxB = Math.max(...b.party.map(p => p.level));
-            return maxA - maxB;
-          })
-          .map((battle, i) => (
-            <TrainerCard
-              key={i}
-              title={`${battle.rival} \u2014 ${battle.location}`}
-              subtitle={battle.starterMatchup ? `If player chose: ${battle.starterMatchup}` : ''}
-              typeBadge="Rival"
-              party={battle.party}
-            />
-          ))}
-      </div>
-
-      {/* Routes */}
-      <div className="guide-section">
-        <h2 className="guide-section-title">{'\uD83D\uDDFA\uFE0F'} Wild Encounters by Location</h2>
-        {routeNames.map(name => (
-          <RouteCard key={name} name={name} route={data.routes[name]} />
-        ))}
-      </div>
     </section>
   );
 }

--- a/docs/src/pages/JournalPage.tsx
+++ b/docs/src/pages/JournalPage.tsx
@@ -3,8 +3,71 @@ import StatsBanner from '../components/StatsBanner';
 import JournalCard from '../components/JournalCard';
 import type { JournalEntry } from '../lib/types';
 
+const ENTRIES_PER_PAGE = 10;
+
+function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}) {
+  if (totalPages <= 1) return null;
+
+  // Build page numbers with ellipsis
+  const pages: (number | '...')[] = [];
+  for (let i = 0; i < totalPages; i++) {
+    if (
+      i === 0 ||
+      i === totalPages - 1 ||
+      (i >= currentPage - 1 && i <= currentPage + 1)
+    ) {
+      pages.push(i);
+    } else if (pages[pages.length - 1] !== '...') {
+      pages.push('...');
+    }
+  }
+
+  return (
+    <div className="pagination">
+      <button
+        className="pagination-btn"
+        disabled={currentPage === 0}
+        onClick={() => onPageChange(currentPage - 1)}
+      >
+        Prev
+      </button>
+      {pages.map((p, i) =>
+        p === '...' ? (
+          <span key={`ellipsis-${i}`} className="pagination-ellipsis">
+            ...
+          </span>
+        ) : (
+          <button
+            key={p}
+            className={`pagination-btn${p === currentPage ? ' active' : ''}`}
+            onClick={() => onPageChange(p)}
+          >
+            {p + 1}
+          </button>
+        ),
+      )}
+      <button
+        className="pagination-btn"
+        disabled={currentPage === totalPages - 1}
+        onClick={() => onPageChange(currentPage + 1)}
+      >
+        Next
+      </button>
+    </div>
+  );
+}
+
 export default function JournalPage() {
   const [entries, setEntries] = useState<JournalEntry[]>([]);
+  const [currentPage, setCurrentPage] = useState(0);
 
   useEffect(() => {
     fetch(import.meta.env.BASE_URL + 'data/journals.json')
@@ -14,20 +77,46 @@ export default function JournalPage() {
   }, []);
 
   const sorted = [...entries].sort((a, b) => b.cycle - a.cycle);
+  const totalPages = Math.ceil(sorted.length / ENTRIES_PER_PAGE);
+  const pageEntries = sorted.slice(
+    currentPage * ENTRIES_PER_PAGE,
+    (currentPage + 1) * ENTRIES_PER_PAGE,
+  );
+
+  const startCycle = pageEntries.length > 0 ? pageEntries[0].cycle : 0;
+  const endCycle =
+    pageEntries.length > 0 ? pageEntries[pageEntries.length - 1].cycle : 0;
+
+  function handlePageChange(page: number) {
+    setCurrentPage(page);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
 
   return (
     <>
       <StatsBanner entries={entries} />
       <main className="main-content active">
+        {totalPages > 1 && (
+          <div className="pagination-info">
+            Showing cycles {startCycle}&ndash;{endCycle} of {sorted.length} total
+          </div>
+        )}
         <div className="timeline">
           {sorted.length === 0 ? (
             <div className="loading-state">
               <p>No research logs available.</p>
             </div>
           ) : (
-            sorted.map(entry => <JournalCard key={entry.cycle} entry={entry} />)
+            pageEntries.map(entry => (
+              <JournalCard key={entry.cycle} entry={entry} />
+            ))
           )}
         </div>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+        />
       </main>
     </>
   );

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -1388,3 +1388,366 @@ body::after {
     font-size: 11px;
   }
 }
+
+/* ============================================================
+   PAGINATION
+   ============================================================ */
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 24px 0 16px;
+  flex-wrap: wrap;
+}
+
+.pagination-btn {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  padding: 6px 12px;
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-sm);
+  background: var(--lab-panel);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.pagination-btn:hover:not(:disabled) {
+  border-color: var(--text-accent);
+  color: var(--text-accent);
+  box-shadow: 0 0 8px rgba(79, 195, 247, 0.2);
+}
+
+.pagination-btn.active {
+  background: var(--text-accent);
+  color: var(--lab-bg);
+  border-color: var(--text-accent);
+  font-weight: 700;
+}
+
+.pagination-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.pagination-ellipsis {
+  color: var(--text-muted);
+  padding: 0 4px;
+  font-family: var(--font-mono);
+}
+
+.pagination-info {
+  text-align: center;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 8px 0;
+  margin-bottom: 8px;
+}
+
+/* ============================================================
+   GAME GUIDE — STATS BANNER
+   ============================================================ */
+
+.guide-stats-banner {
+  display: flex;
+  justify-content: center;
+  gap: 32px;
+  padding: 20px 24px;
+  margin-bottom: 16px;
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  flex-wrap: wrap;
+}
+
+.guide-stat {
+  text-align: center;
+}
+
+.guide-stat-value {
+  font-family: var(--font-pixel);
+  font-size: 18px;
+  color: var(--green-bright);
+  margin-bottom: 4px;
+}
+
+.guide-stat-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+/* ============================================================
+   GAME GUIDE — TOOLBAR (Search + Quick Nav)
+   ============================================================ */
+
+.guide-toolbar {
+  margin-bottom: 20px;
+}
+
+.guide-search-wrap {
+  position: relative;
+  margin-bottom: 12px;
+}
+
+.guide-search {
+  width: 100%;
+  padding: 10px 36px 10px 14px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--text-primary);
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.guide-search:focus {
+  border-color: var(--text-accent);
+  box-shadow: 0 0 12px rgba(79, 195, 247, 0.15);
+}
+
+.guide-search::placeholder {
+  color: var(--text-muted);
+}
+
+.guide-search-clear {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px;
+}
+
+.guide-search-clear:hover {
+  color: var(--text-primary);
+}
+
+.guide-quick-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.guide-quick-nav-item {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--lab-bg-lighter);
+  border: 1px solid var(--lab-panel-border);
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+
+.guide-quick-nav-item:hover {
+  border-color: var(--text-accent);
+  color: var(--text-accent);
+}
+
+/* ============================================================
+   GAME GUIDE — PROGRESSION TIMELINE
+   ============================================================ */
+
+.progression-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.progression-step {
+  border-left: 3px solid var(--lab-panel-border);
+  padding-left: 16px;
+  transition: border-color var(--transition-fast);
+}
+
+.progression-step.step-gym {
+  border-left-color: var(--yellow-bright);
+}
+
+.progression-step.step-rival {
+  border-left-color: var(--red-bright);
+}
+
+.progression-step.step-route {
+  border-left-color: var(--green-bright);
+}
+
+.progression-step.step-elite {
+  border-left-color: var(--purple-bright);
+}
+
+.progression-step.step-champion {
+  border-left-color: #ffd700;
+}
+
+.progression-step.step-starter {
+  border-left-color: var(--text-accent);
+}
+
+.progression-step.step-landmark {
+  border-left-color: var(--blue-bright);
+}
+
+.progression-step.step-chapter {
+  border-left: none;
+  padding-left: 0;
+  margin-top: 24px;
+  margin-bottom: 8px;
+}
+
+.progression-step.step-chapter:first-child {
+  margin-top: 0;
+}
+
+/* ============================================================
+   GAME GUIDE — CHAPTER HEADERS
+   ============================================================ */
+
+.progression-chapter {
+  padding: 16px 0 8px;
+}
+
+.progression-chapter-title {
+  font-family: var(--font-pixel);
+  font-size: 14px;
+  color: var(--text-accent);
+  margin-bottom: 6px;
+  letter-spacing: 0.5px;
+}
+
+.progression-chapter-desc {
+  font-family: var(--font-ui);
+  font-size: 14px;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+/* ============================================================
+   GAME GUIDE — LANDMARK CARDS
+   ============================================================ */
+
+.landmark-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--lab-bg-lighter);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-md);
+}
+
+.landmark-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.landmark-name {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.landmark-desc {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+/* ============================================================
+   GAME GUIDE — ROUTE GROUP (multi-area locations)
+   ============================================================ */
+
+.route-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.route-group-label {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  padding: 4px 0;
+}
+
+/* ============================================================
+   GAME GUIDE — NEW SPECIES BADGES
+   ============================================================ */
+
+.new-species-badge {
+  display: inline-block;
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  padding: 2px 5px;
+  margin-left: 6px;
+  background: var(--green-bright);
+  color: var(--lab-bg);
+  border-radius: var(--radius-sm);
+  font-weight: 700;
+  vertical-align: middle;
+  letter-spacing: 0.5px;
+}
+
+.new-count-badge {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 2px 8px;
+  background: rgba(0, 230, 118, 0.15);
+  color: var(--green-bright);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(0, 230, 118, 0.3);
+}
+
+/* ============================================================
+   RESPONSIVE — Pagination & Guide
+   ============================================================ */
+
+@media (max-width: 600px) {
+  .guide-stats-banner {
+    gap: 16px;
+    padding: 14px 16px;
+  }
+
+  .guide-stat-value {
+    font-size: 14px;
+  }
+
+  .guide-quick-nav-item {
+    font-size: 10px;
+    padding: 3px 8px;
+  }
+
+  .progression-step {
+    padding-left: 10px;
+  }
+
+  .progression-chapter-title {
+    font-size: 11px;
+  }
+
+  .pagination {
+    gap: 4px;
+  }
+
+  .pagination-btn {
+    padding: 5px 8px;
+    font-size: 11px;
+  }
+}


### PR DESCRIPTION
…s badges

- Add pagination to Research Logs page (10 entries per page) with page navigation, ellipsis for large ranges, and scroll-to-top
- Rewrite Game Guide to follow Emerald's natural game progression instead of grouping by category, inspired by Nuzlocke tracker apps
- Add chapter headers dividing the journey into 11 chapters + postgame
- Add search/filter bar and quick-nav links for the guide
- Add stats banner showing total locations, species, trainers, level range
- Add "NEW" badges on species appearing for the first time at each route
- Add "X new" count badges on route card headers
- Add landmark cards for towns/cities with flavor text
- Support multi-area locations (caves, dungeons) with grouped route cards

https://claude.ai/code/session_01WDzETdzUFJZuWf3HSaBWZd