### PR TITLE
Add Downloads tab to docs website with releases, patching instruction…

### DIFF
--- a/docs/build-scripts/build-releases.mjs
+++ b/docs/build-scripts/build-releases.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/**
+ * Build script: fetches the latest GitHub releases and writes docs/public/data/releases.json
+ * Uses the public GitHub API (no auth required).
+ * Run: node docs/build-scripts/build-releases.mjs
+ */
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DOCS_DIR = join(__dirname, '..');
+const OUTPUT_DIR = join(DOCS_DIR, 'public', 'data');
+const OUTPUT_FILE = join(OUTPUT_DIR, 'releases.json');
+
+const REPO = 'alvarodms/agentoak';
+const API_URL = `https://api.github.com/repos/${REPO}/releases?per_page=5`;
+
+async function main() {
+  let releases = [];
+
+  try {
+    const res = await fetch(API_URL, {
+      headers: { 'Accept': 'application/vnd.github+json' },
+    });
+
+    if (!res.ok) {
+      console.warn(`⚠ GitHub API returned ${res.status} — writing empty releases`);
+    } else {
+      const data = await res.json();
+      releases = data.map(release => {
+        const ipsAsset = release.assets?.find(a => a.name.endsWith('.ips'));
+        return {
+          tag: release.tag_name,
+          name: release.name || release.tag_name,
+          date: release.published_at,
+          body: release.body || '',
+          url: release.html_url,
+          ipsUrl: ipsAsset?.browser_download_url || null,
+          ipsName: ipsAsset?.name || null,
+        };
+      });
+    }
+  } catch (err) {
+    console.warn(`⚠ Failed to fetch releases: ${err.message} — writing empty array`);
+  }
+
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  await writeFile(OUTPUT_FILE, JSON.stringify(releases, null, 2) + '\n');
+  console.log(`✔ Generated ${OUTPUT_FILE} (${releases.length} releases)`);
+}
+
+main().catch(err => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build:data": "node build-scripts/build-journals.mjs && node build-scripts/build-game-guide.mjs && node build-scripts/build-strategy.mjs",
+    "build:data": "node build-scripts/build-journals.mjs && node build-scripts/build-game-guide.mjs && node build-scripts/build-strategy.mjs && node build-scripts/build-releases.mjs",
     "build": "npm run build:data && vite build",
     "preview": "vite preview"
   },

--- a/docs/src/components/Header.tsx
+++ b/docs/src/components/Header.tsx
@@ -6,6 +6,7 @@ const NAV_ITEMS = [
   { href: '/strategy', label: 'Strategy' },
   { href: '/roadmap', label: 'Roadmap' },
   { href: '/about', label: 'About' },
+  { href: '/downloads', label: 'Downloads' },
 ];
 
 export default function Header() {

--- a/docs/src/lib/types.ts
+++ b/docs/src/lib/types.ts
@@ -105,6 +105,16 @@ export interface RoadmapUpcomingEntry {
   complexity?: string;
 }
 
+export interface ReleaseEntry {
+  tag: string;
+  name: string;
+  date: string;
+  body: string;
+  url: string;
+  ipsUrl: string | null;
+  ipsName: string | null;
+}
+
 export interface StrategyData {
   vision?: {
     title: string;

--- a/docs/src/main.tsx
+++ b/docs/src/main.tsx
@@ -7,6 +7,7 @@ import GuidePage from './pages/GuidePage';
 import StrategyPage from './pages/StrategyPage';
 import RoadmapPage from './pages/RoadmapPage';
 import AboutPage from './pages/AboutPage';
+import DownloadsPage from './pages/DownloadsPage';
 import './styles/globals.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
@@ -19,6 +20,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <Route path="/strategy" element={<StrategyPage />} />
           <Route path="/roadmap" element={<RoadmapPage />} />
           <Route path="/about" element={<AboutPage />} />
+          <Route path="/downloads" element={<DownloadsPage />} />
         </Routes>
       </Layout>
     </HashRouter>

--- a/docs/src/pages/DownloadsPage.tsx
+++ b/docs/src/pages/DownloadsPage.tsx
@@ -1,0 +1,148 @@
+import { useState, useEffect } from 'react';
+import type { ReleaseEntry } from '../lib/types';
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+/** Minimal markdown-to-JSX for release bodies (bullets, bold, headings, links). */
+function ReleaseBody({ markdown }: { markdown: string }) {
+  const lines = markdown.split('\n');
+  const elements: JSX.Element[] = [];
+  let listItems: string[] = [];
+  let key = 0;
+
+  const flushList = () => {
+    if (listItems.length === 0) return;
+    elements.push(
+      <ul key={key++}>
+        {listItems.map((item, i) => (
+          <li key={i} dangerouslySetInnerHTML={{ __html: inlineFormat(item) }} />
+        ))}
+      </ul>,
+    );
+    listItems = [];
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (/^[-*]\s+/.test(trimmed)) {
+      listItems.push(trimmed.replace(/^[-*]\s+/, ''));
+    } else {
+      flushList();
+      if (trimmed === '') continue;
+      if (/^#{1,3}\s+/.test(trimmed)) {
+        const text = trimmed.replace(/^#{1,3}\s+/, '');
+        elements.push(<h4 key={key++} dangerouslySetInnerHTML={{ __html: inlineFormat(text) }} />);
+      } else {
+        elements.push(<p key={key++} dangerouslySetInnerHTML={{ __html: inlineFormat(trimmed) }} />);
+      }
+    }
+  }
+  flushList();
+
+  return <div className="release-changelog">{elements}</div>;
+}
+
+function inlineFormat(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/`(.+?)`/g, '<code>$1</code>')
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+}
+
+export default function DownloadsPage() {
+  const [releases, setReleases] = useState<ReleaseEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`${import.meta.env.BASE_URL}data/releases.json`)
+      .then(r => r.json())
+      .then(data => { setReleases(data); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, []);
+
+  return (
+    <section className="downloads-view active">
+      <div className="info-card">
+        <h3>{'\uD83C\uDFAE'} How to Play</h3>
+        <p>Follow these steps to patch and play <strong>Legends of Hoenn</strong>:</p>
+        <ol className="patching-steps">
+          <li>
+            <strong>Get the base ROM</strong> &mdash; You need a <strong>Pok&eacute;mon Emerald (U)</strong> ROM file.
+            <br />
+            <span className="text-muted">
+              SHA-1: <code>f3ae088181bf583e55daf962a92bb46f4f1d07b7</code>
+            </span>
+            <br />
+            <span className="text-muted">We cannot provide ROM files. Please source your own legally.</span>
+          </li>
+          <li>
+            <strong>Download the patch</strong> &mdash; Grab the <code>.ips</code> patch file from the latest release below.
+          </li>
+          <li>
+            <strong>Apply the patch</strong> &mdash; Use an online patcher like{' '}
+            <a href="https://www.marcrobledo.com/RomPatcher.js/" target="_blank" rel="noopener noreferrer">
+              RomPatcher.js
+            </a>{' '}
+            to apply the <code>.ips</code> file to your base ROM.
+          </li>
+          <li>
+            <strong>Play!</strong> &mdash; Load the patched <code>.gba</code> file in any GBA emulator
+            (mGBA, VBA-M, etc.) or flash cart.
+          </li>
+        </ol>
+      </div>
+
+      <h2 className="section-heading">Latest Releases</h2>
+
+      {loading && <div className="info-card"><p>Loading releases&hellip;</p></div>}
+
+      {!loading && releases.length === 0 && (
+        <div className="info-card">
+          <p>
+            No releases available yet. Check the{' '}
+            <a href="https://github.com/alvarodms/agentoak/releases" target="_blank" rel="noopener noreferrer">
+              GitHub releases page
+            </a>{' '}
+            for updates.
+          </p>
+        </div>
+      )}
+
+      {releases.map(release => (
+        <div key={release.tag} className="release-card">
+          <div className="release-card-header">
+            <div>
+              <span className="release-tag">{release.tag}</span>
+              <span className="release-name">{release.name}</span>
+            </div>
+            <span className="release-date">{formatDate(release.date)}</span>
+          </div>
+
+          {release.body && <ReleaseBody markdown={release.body} />}
+
+          <div className="release-actions">
+            {release.ipsUrl ? (
+              <a href={release.ipsUrl} className="download-btn" download>
+                {'\u2B07'} Download Patch
+                {release.ipsName && <span className="download-filename">{release.ipsName}</span>}
+              </a>
+            ) : (
+              <a href={release.url} className="download-btn download-btn-secondary" target="_blank" rel="noopener noreferrer">
+                View on GitHub
+              </a>
+            )}
+            <a href={release.url} className="release-github-link" target="_blank" rel="noopener noreferrer">
+              View release on GitHub &rarr;
+            </a>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -657,7 +657,7 @@ body::after {
 }
 
 /* ---- View Containers ---- */
-.strategy-view, .about-view, .guide-view {
+.strategy-view, .about-view, .guide-view, .downloads-view {
   position: relative;
   z-index: 5;
   max-width: 960px;
@@ -789,7 +789,7 @@ body::after {
     gap: 16px;
   }
 
-  .main-content, .strategy-view, .about-view, .guide-view, .roadmap-view {
+  .main-content, .strategy-view, .about-view, .guide-view, .roadmap-view, .downloads-view {
     padding: 20px 12px 60px;
   }
 
@@ -1750,4 +1750,240 @@ body::after {
     padding: 5px 8px;
     font-size: 11px;
   }
+
+  .release-card-header {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .download-btn {
+    width: 100%;
+    text-align: center;
+    justify-content: center;
+  }
+}
+
+/* ---- Downloads Page ---- */
+
+.section-heading {
+  font-family: var(--font-pixel);
+  font-size: 12px;
+  color: var(--green-bright);
+  margin-bottom: 20px;
+  text-shadow: 0 0 10px rgba(0, 230, 118, 0.3);
+}
+
+.patching-steps {
+  list-style: none;
+  padding: 0;
+  counter-reset: steps;
+}
+
+.patching-steps li {
+  padding: 10px 0 10px 36px;
+  position: relative;
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  counter-increment: steps;
+}
+
+.patching-steps li::before {
+  content: counter(steps);
+  position: absolute;
+  left: 0;
+  top: 10px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--green-dark);
+  color: var(--green-bright);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.patching-steps a {
+  color: var(--text-accent);
+}
+
+.patching-steps code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+}
+
+.patching-steps .text-muted {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.release-card {
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-left: 3px solid var(--green-dim);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  margin-bottom: 20px;
+  box-shadow: var(--shadow-card);
+  transition: border-color var(--transition-normal);
+}
+
+.release-card:hover {
+  border-left-color: var(--green-bright);
+}
+
+.release-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 16px;
+  gap: 12px;
+}
+
+.release-tag {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--green-dark);
+  color: var(--green-bright);
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  margin-right: 10px;
+}
+
+.release-name {
+  font-family: var(--font-ui);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.release-date {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.release-changelog {
+  margin-bottom: 16px;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(30, 58, 82, 0.5);
+}
+
+.release-changelog h4 {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.release-changelog p {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 8px;
+}
+
+.release-changelog p:last-child {
+  margin-bottom: 0;
+}
+
+.release-changelog ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.release-changelog ul li {
+  padding: 4px 0 4px 18px;
+  position: relative;
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.release-changelog ul li::before {
+  content: '\25B8';
+  position: absolute;
+  left: 0;
+  color: var(--green-dim);
+}
+
+.release-changelog code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+}
+
+.release-changelog a {
+  color: var(--text-accent);
+}
+
+.release-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 700;
+  padding: 10px 20px;
+  border-radius: var(--radius-md);
+  background: var(--green-bright);
+  color: var(--lab-bg);
+  text-decoration: none;
+  transition: box-shadow var(--transition-normal), background var(--transition-normal);
+}
+
+.download-btn:hover {
+  background: #2eff8e;
+  box-shadow: 0 0 20px rgba(0, 230, 118, 0.4);
+}
+
+.download-btn-secondary {
+  background: var(--lab-panel-border);
+  color: var(--text-primary);
+}
+
+.download-btn-secondary:hover {
+  background: var(--text-muted);
+  box-shadow: none;
+}
+
+.download-filename {
+  font-size: 11px;
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+.release-github-link {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.release-github-link:hover {
+  color: var(--text-accent);
 }


### PR DESCRIPTION
…s, and IPS patch links

- New build script (build-releases.mjs) fetches latest 5 releases from GitHub API at build time
- DownloadsPage component shows patching instructions (ROM needed, RomPatcher.js link) and release cards with changelogs and download buttons
- Wired up /downloads route and nav tab
- Styled to match existing lab terminal theme

https://claude.ai/code/session_01XYGKQvKUszZMwkbR3nUkE7