### PR TITLE
Fix deferred issue comments: stop re-commenting every cycle, add stal…

### DIFF
--- a/src/agent/prompt-sections.ts
+++ b/src/agent/prompt-sections.ts
@@ -34,9 +34,28 @@ export function formatIssueSection(issueContext: string): string {
 }
 
 /** Build the "Deferred Issue Backlog" section (returns empty string if absent). */
-export function formatBacklogSection(issueBacklog: string): string {
-  if (!issueBacklog) return "";
-  return `\n\n## Deferred Issue Backlog\n\nThe following issues were deferred from earlier cycles. You may pick one up this cycle if the timing is right — include it in \`issueActions\` with action "accept" along with a brief response.\n\n${issueBacklog}\n`;
+export function formatBacklogSection(
+  issueBacklog: string,
+  staleIssues?: Array<{ issueNumber: number; title: string; deferredAtCycle: number }>,
+): string {
+  const hasBacklog = !!issueBacklog;
+  const hasStale = staleIssues && staleIssues.length > 0;
+  if (!hasBacklog && !hasStale) return "";
+
+  let section = "\n\n## Deferred Issue Backlog\n\n";
+
+  if (hasBacklog) {
+    section += `The following issues were deferred from earlier cycles. They will be carried forward automatically — you do **NOT** need to include them in \`issueActions\`. Only include a backlog issue in \`issueActions\` if you want to **accept** it this cycle.\n\n${issueBacklog}\n`;
+  }
+
+  if (hasStale) {
+    const staleLines = staleIssues.map(
+      (i) => `- #${i.issueNumber}: ${i.title} (deferred since cycle ${i.deferredAtCycle})`,
+    ).join("\n");
+    section += `\n### Stale Issues (deferred 10+ cycles)\n\nThese issues have been sitting in the backlog for a long time. Please re-evaluate each one and include it in \`issueActions\`:\n- **accept**: Pick it up this cycle\n- **reject**: It no longer aligns with the project direction — close it with a reason\n- **defer**: Still worth keeping — provide a brief justification for why\n\n${staleLines}\n`;
+  }
+
+  return section;
 }
 
 /** The Pokédex MCP tools reference block, used by planners and the Pokémon Specialist advisor. */
@@ -135,7 +154,12 @@ You have access to a **Gameplay Designer** agent that can produce detailed, data
 
 /** The issue-response and help-request instructions appended to planner prompts. */
 export function formatPlannerClosingInstructions(): string {
-  return `If there are community issues listed above, review each one and include your decisions in the \`issueActions\` array. You have full freedom to accept, defer, reject, or ask for more info. If an accepted issue should shape this cycle's objective, incorporate it.
+  return `**Issue handling rules:**
+- **New community issues**: Review each one and include your decisions in the \`issueActions\` array. You have full freedom to accept, defer, reject, or ask for more info.
+- **Regular backlog issues**: Do NOT include them in \`issueActions\` — they are carried forward automatically. Only include a backlog issue if you want to **accept** it this cycle.
+- **Stale backlog issues** (marked in the "Stale Issues" section): You MUST re-evaluate each one and include it in \`issueActions\` with accept, reject, or defer.
+
+If an accepted issue should shape this cycle's objective, incorporate it.
 
 **Important**: When writing issue responses, adopt Professor Oak's warm, encouraging voice — treat contributors like promising young trainers. Be kind, curious, and use gentle Pokémon metaphors. See the /communicate skill for voice examples, though you cannot invoke it during structured output.
 
@@ -154,6 +178,7 @@ export interface PlannerContextParams {
   modeHistorySummary: string;
   issueContext: string;
   issueBacklog: string;
+  staleIssues?: Array<{ issueNumber: number; title: string; deferredAtCycle: number }>;
   extraMemoryFiles?: string[];
 }
 
@@ -171,7 +196,7 @@ export function buildPlannerContextSections(params: PlannerContextParams): strin
   b.raw("\n" + formatPokedexToolsSection());
   b.heading("Available Modes", formatModeList());
   b.raw(formatIssueSection(params.issueContext));
-  b.raw(formatBacklogSection(params.issueBacklog));
+  b.raw(formatBacklogSection(params.issueBacklog, params.staleIssues));
   return b.build();
 }
 

--- a/src/cycle/planner.ts
+++ b/src/cycle/planner.ts
@@ -211,11 +211,12 @@ export async function planCycle(
   cycleNumber: number,
   issueContext: string = "",
   issueBacklog: string = "",
+  staleIssues?: Array<{ issueNumber: number; title: string; deferredAtCycle: number }>,
 ): Promise<CyclePlan> {
   // Dispatch to team planner if conditions are met
   if (shouldUseTeamPlanning(cycleNumber, undefined, issueContext.length > 0)) {
     logger.info("[Planning] Using team planning (multi-perspective advisory)");
-    return planCycleWithTeam(recentJournalSummaries, cycleNumber, issueContext, issueBacklog);
+    return planCycleWithTeam(recentJournalSummaries, cycleNumber, issueContext, issueBacklog, staleIssues);
   }
 
   logger.info("[Planning] Using single planner");
@@ -230,6 +231,7 @@ export async function planCycle(
     modeHistorySummary,
     issueContext,
     issueBacklog,
+    staleIssues,
   });
 
   const prompt = `You are Agent Oak's planning module. Decide what the next autonomous cycle should focus on.

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -29,7 +29,7 @@ import {
 } from "../git/committer.js";
 import { validateCycle } from "../reflection/validator.js";
 import type { ValidationResult } from "../reflection/validator.js";
-import { fetchNewCommunityIssues, formatIssuesForPrompt, executeIssueActions, createHelpRequest, readIssueBacklog, updateIssueBacklog, addIssueToBacklog, postIssueClosingComment, postIssuePartialDeliveryComment } from "../github/issues.js";
+import { fetchNewCommunityIssues, formatIssuesForPrompt, executeIssueActions, createHelpRequest, readIssueBacklog, updateIssueBacklog, addIssueToBacklog, getStaleBacklogIssues, postIssueClosingComment, postIssuePartialDeliveryComment } from "../github/issues.js";
 import { closeIssue, addLabelsToIssue, AGENT_LABELS } from "../github/client.js";
 import { cycleLogger } from "../utils/logger.js";
 import { PROJECT_ROOT, ARTIFACTS_DIR } from "../utils/paths.js";
@@ -89,8 +89,13 @@ async function runPlanningPhase(
   const communityIssues = await fetchNewCommunityIssues();
   const issueContext = formatIssuesForPrompt(communityIssues);
   const issueBacklog = readIssueBacklog();
+  const staleIssues = getStaleBacklogIssues(cycleNumber);
 
-  const plan = await planCycle(lastJournal, cycleNumber, issueContext, issueBacklog);
+  if (staleIssues.length > 0) {
+    log.info(`  Found ${staleIssues.length} stale backlog issue(s) for re-review.`);
+  }
+
+  const plan = await planCycle(lastJournal, cycleNumber, issueContext, issueBacklog, staleIssues);
   log.info(`Plan: [${plan.mode}] ${plan.objective}`);
 
   // Execute issue actions only for newly fetched community issues — not for
@@ -105,8 +110,6 @@ async function runPlanningPhase(
   }
 
   // Post comments on backlog issues being accepted this cycle.
-  // These were already reviewed in a prior cycle (so executeIssueActions was skipped above),
-  // but now that the agent is picking them up we should post the acceptance/in-progress comment.
   const backlogAcceptActions = plan.issueActions.filter(
     (a) => !communityIssueNumbers.has(a.issueNumber) && a.action === "accept",
   );
@@ -115,10 +118,24 @@ async function runPlanningPhase(
     await executeIssueActions(backlogAcceptActions);
   }
 
+  // Post comments on stale backlog issues that the planner re-evaluated
+  // (accept is handled above; this covers reject and re-defer responses).
+  const staleIssueNumbers = new Set(staleIssues.map((i) => i.issueNumber));
+  const staleReviewActions = plan.issueActions.filter(
+    (a) =>
+      staleIssueNumbers.has(a.issueNumber) &&
+      !communityIssueNumbers.has(a.issueNumber) &&
+      a.action !== "accept", // accepts already handled above
+  );
+  if (staleReviewActions.length > 0) {
+    log.info(`  Posting comments on ${staleReviewActions.length} stale issue(s) re-reviewed...`);
+    await executeIssueActions(staleReviewActions);
+  }
+
   // Update the deferred-issue backlog based on this cycle's actions
   // (all actions, including planner decisions on backlog issues)
   const issueMap = new Map(communityIssues.map((i) => [i.number, i]));
-  updateIssueBacklog(plan.issueActions, issueMap);
+  updateIssueBacklog(plan.issueActions, issueMap, cycleNumber, staleIssueNumbers);
 
   // Any issue presented to the planner but NOT included in issueActions must
   // still be marked agent-reviewed so it doesn't resurface on the next cycle.
@@ -671,7 +688,7 @@ export async function runCycle(): Promise<void> {
           await postIssuePartialDeliveryComment(issueNumber, reason, "defer");
           await addLabelsToIssue(issueNumber, [AGENT_LABELS.deferred]);
           // Re-add to backlog so it surfaces in a future cycle
-          addIssueToBacklog(issueNumber, `Issue #${issueNumber}`);
+          addIssueToBacklog(issueNumber, `Issue #${issueNumber}`, cycleNumber);
         }
       }
 

--- a/src/cycle/team-planner.ts
+++ b/src/cycle/team-planner.ts
@@ -82,6 +82,7 @@ export async function planCycleWithTeam(
   cycleNumber: number,
   issueContext: string = "",
   issueBacklog: string = "",
+  staleIssues?: Array<{ issueNumber: number; title: string; deferredAtCycle: number }>,
 ): Promise<CyclePlan> {
   const model = process.env.ANTHROPIC_MODEL;
 
@@ -115,7 +116,7 @@ export async function planCycleWithTeam(
     logger.warn("[Team Planning] All advisors failed — falling back to single planner");
     // Dynamic import to avoid circular dependency with planner.ts
     const { planCycle } = await import("./planner.js");
-    return planCycle(recentJournalSummaries, cycleNumber, issueContext, issueBacklog);
+    return planCycle(recentJournalSummaries, cycleNumber, issueContext, issueBacklog, staleIssues);
   }
 
   // Phase B: Build Producer prompt (shared planner context + memos)
@@ -127,6 +128,7 @@ export async function planCycleWithTeam(
     modeHistorySummary,
     issueContext,
     issueBacklog,
+    staleIssues,
     extraMemoryFiles: [
       "`memory/pokemon-knowledge.md` — Pokémon game/ROM hack research findings (maintained by the Pokémon Specialist advisor)",
     ],

--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -24,6 +24,46 @@ import { MEMORY_DIR } from "../utils/paths.js";
 
 const BACKLOG_FILE = path.join(MEMORY_DIR, "issue-backlog.md");
 
+/** Parsed backlog entry with cycle-tracking metadata. */
+export interface BacklogEntry {
+  issueNumber: number;
+  title: string;
+  /** The cycle number when this issue was deferred. 0 if unknown (legacy entries). */
+  deferredAtCycle: number;
+}
+
+const BACKLOG_LINE_RE = /^- #(\d+):\s*(.+?)(?:\s*\(deferred: cycle (\d+)\))?$/;
+
+/** Format a single backlog entry as a markdown line. */
+function formatBacklogLine(entry: BacklogEntry): string {
+  return `- #${entry.issueNumber}: ${entry.title} (deferred: cycle ${entry.deferredAtCycle})`;
+}
+
+/**
+ * Parse the backlog file into structured entries.
+ * Legacy lines without a cycle number default to deferredAtCycle = 0.
+ */
+export function parseBacklogEntries(): BacklogEntry[] {
+  try {
+    if (!fs.existsSync(BACKLOG_FILE)) return [];
+    const entries: BacklogEntry[] = [];
+    for (const line of fs.readFileSync(BACKLOG_FILE, "utf-8").split("\n")) {
+      const match = line.match(BACKLOG_LINE_RE);
+      if (match) {
+        entries.push({
+          issueNumber: parseInt(match[1], 10),
+          title: match[2].trim(),
+          deferredAtCycle: match[3] ? parseInt(match[3], 10) : 0,
+        });
+      }
+    }
+    return entries;
+  } catch (err) {
+    logger.error(`Failed to parse issue backlog: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+}
+
 /**
  * Read the current issue backlog file contents.
  * Returns an empty string if the file does not exist yet.
@@ -40,6 +80,15 @@ export function readIssueBacklog(): string {
 }
 
 /**
+ * Get backlog issues that have been deferred for >= threshold cycles.
+ */
+export function getStaleBacklogIssues(currentCycle: number, threshold = 10): BacklogEntry[] {
+  return parseBacklogEntries().filter(
+    (e) => currentCycle - e.deferredAtCycle >= threshold,
+  );
+}
+
+/**
  * Add a single issue to the backlog file unconditionally.
  *
  * Unlike updateIssueBacklog (which routes planning-phase actions), this is a
@@ -47,63 +96,47 @@ export function readIssueBacklog(): string {
  * Always writes the file so the change is not lost due to the "nothing changed"
  * early-return guard inside updateIssueBacklog.
  */
-export function addIssueToBacklog(issueNumber: number, title: string): void {
-  const existing = new Map<number, string>();
-  try {
-    if (fs.existsSync(BACKLOG_FILE)) {
-      for (const line of fs.readFileSync(BACKLOG_FILE, "utf-8").split("\n")) {
-        const match = line.match(/^- #(\d+):/);
-        if (match) existing.set(parseInt(match[1], 10), line);
-      }
-    }
-  } catch (err) {
-    logger.error(`Failed to parse issue backlog: ${err instanceof Error ? err.message : String(err)}`);
+export function addIssueToBacklog(issueNumber: number, title: string, cycleNumber: number): void {
+  const existing = new Map<number, BacklogEntry>();
+  for (const entry of parseBacklogEntries()) {
+    existing.set(entry.issueNumber, entry);
   }
 
-  existing.set(issueNumber, `- #${issueNumber}: ${title}`);
+  existing.set(issueNumber, { issueNumber, title, deferredAtCycle: cycleNumber });
 
-  const header = "# Issue Backlog\n\nDeferred community issues for future consideration.\n";
-  const entries = [...existing.values()];
-  const content = header + "\n" + entries.join("\n") + "\n";
-
-  try {
-    fs.mkdirSync(path.dirname(BACKLOG_FILE), { recursive: true });
-    fs.writeFileSync(BACKLOG_FILE, content, "utf-8");
-    logger.info(`Added issue #${issueNumber} to backlog (${entries.length} item(s) total).`);
-  } catch (err) {
-    logger.error(`Failed to write issue backlog: ${err instanceof Error ? err.message : String(err)}`);
-  }
+  writeBacklogEntries([...existing.values()]);
+  logger.info(`Added issue #${issueNumber} to backlog (${existing.size} item(s) total).`);
 }
 
 /**
  * Update the issue backlog based on the planner's actions:
- * - "defer": add the issue to the backlog (if not already present)
+ * - "defer": add the issue to the backlog (if not already present), or update cycle if re-deferring a stale issue
  * - "accept" / "reject": remove the issue from the backlog
  * "need-info" leaves the backlog unchanged; the issue stays deferred if it was there.
  */
 export function updateIssueBacklog(
   actions: IssueAction[],
   issueMap: Map<number, GitHubIssue>,
+  cycleNumber: number,
+  staleIssueNumbers?: Set<number>,
 ): void {
-  // Parse existing entries keyed by issue number
-  const existing = new Map<number, string>();
-  try {
-    if (fs.existsSync(BACKLOG_FILE)) {
-      for (const line of fs.readFileSync(BACKLOG_FILE, "utf-8").split("\n")) {
-        const match = line.match(/^- #(\d+):/);
-        if (match) existing.set(parseInt(match[1], 10), line);
-      }
-    }
-  } catch (err) {
-    logger.error(`Failed to parse issue backlog: ${err instanceof Error ? err.message : String(err)}`);
+  const existing = new Map<number, BacklogEntry>();
+  for (const entry of parseBacklogEntries()) {
+    existing.set(entry.issueNumber, entry);
   }
 
   let changed = false;
   for (const action of actions) {
     if (action.action === "defer") {
       if (!existing.has(action.issueNumber)) {
+        // New deferral
         const title = issueMap.get(action.issueNumber)?.title ?? "Unknown";
-        existing.set(action.issueNumber, `- #${action.issueNumber}: ${title}`);
+        existing.set(action.issueNumber, { issueNumber: action.issueNumber, title, deferredAtCycle: cycleNumber });
+        changed = true;
+      } else if (staleIssueNumbers?.has(action.issueNumber)) {
+        // Re-deferring a stale issue — reset cycle counter
+        const entry = existing.get(action.issueNumber)!;
+        existing.set(action.issueNumber, { ...entry, deferredAtCycle: cycleNumber });
         changed = true;
       }
     } else if (action.action === "accept" || action.action === "reject") {
@@ -117,17 +150,21 @@ export function updateIssueBacklog(
 
   if (!changed && existing.size === 0) return;
 
+  writeBacklogEntries([...existing.values()]);
+  logger.info(`Updated issue backlog (${existing.size} item(s)).`);
+}
+
+/** Write backlog entries to disk. */
+function writeBacklogEntries(entries: BacklogEntry[]): void {
   const header = "# Issue Backlog\n\nDeferred community issues for future consideration.\n";
-  const entries = [...existing.values()];
   const content =
     entries.length > 0
-      ? header + "\n" + entries.join("\n") + "\n"
+      ? header + "\n" + entries.map(formatBacklogLine).join("\n") + "\n"
       : header + "\n*No deferred issues.*\n";
 
   try {
     fs.mkdirSync(path.dirname(BACKLOG_FILE), { recursive: true });
     fs.writeFileSync(BACKLOG_FILE, content, "utf-8");
-    logger.info(`Updated issue backlog (${entries.length} item(s)).`);
   } catch (err) {
     logger.error(`Failed to write issue backlog: ${err instanceof Error ? err.message : String(err)}`);
   }


### PR DESCRIPTION
…eness tracking

Deferred backlog issues were being re-reviewed by the planner every cycle, causing unnecessary issueActions and potential duplicate comments. Now:

- Backlog issues are carried forward silently (planner told not to include them in issueActions unless accepting)
- Backlog entries track when they were deferred: `(deferred: cycle N)`
- Issues deferred for 10+ cycles are flagged as "stale" and presented to the planner for mandatory re-evaluation (accept, reject, or re-defer)
- Only stale re-reviews and accepts trigger new GitHub comments
- Re-deferring a stale issue resets its cycle counter

https://claude.ai/code/session_019VReFGBeyKVRxTq5UYyBzX