### PR TITLE
Fix Game Guide quick nav links breaking with HashRouter

### DIFF
--- a/docs/src/pages/GuidePage.tsx
+++ b/docs/src/pages/GuidePage.tsx
@@ -398,8 +398,13 @@ export default function GuidePage() {
             <a
               key={index}
               className="guide-quick-nav-item"
-              href={`#${step.label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}
+              href="javascript:void(0)"
               title={step.label}
+              onClick={(e) => {
+                e.preventDefault();
+                const id = step.label.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+                document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+              }}
             >
               {step.label.replace(/^Chapter \d+:\s*/, '')}
             </a>


### PR DESCRIPTION
The quick nav chapter links used href="#chapter-name" anchors, which conflicts with HashRouter. Since the app URL is already /#/guide, clicking a nav link would change the hash to #chapter-name, causing React Router to navigate away from the guide page entirely and show no content.

Replace anchor-based navigation with scrollIntoView() via onClick handlers so the links scroll smoothly to the target chapter without changing the route.