### PR TITLE
fix: authenticate GitHub API calls in release data fetch

### DIFF
--- a/.github/workflows/agent-cycle.yml
+++ b/.github/workflows/agent-cycle.yml
@@ -151,6 +151,13 @@ jobs:
       - name: Install docs dependencies
         run: cd docs && npm i
 
+      - name: Fetch release data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p docs/public/data
+          node docs/build-scripts/build-releases.mjs
+
       - name: Build docs site
         run: cd docs && npm run build
 

--- a/docs/build-scripts/build-releases.mjs
+++ b/docs/build-scripts/build-releases.mjs
@@ -2,11 +2,17 @@
 
 /**
  * Build script: fetches the latest GitHub releases and writes docs/public/data/releases.json
- * Uses the public GitHub API (no auth required).
+ *
+ * In CI, a dedicated pipeline step runs this script with GITHUB_TOKEN set so the
+ * request is authenticated (5 000 req/h instead of 60). The subsequent `npm run build`
+ * invocation detects the already-generated file and skips re-fetching.
+ *
+ * For local dev the script still works without a token (unauthenticated fallback).
+ *
  * Run: node docs/build-scripts/build-releases.mjs
  */
 
-import { writeFile, mkdir } from 'node:fs/promises';
+import { writeFile, mkdir, access } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -15,16 +21,28 @@ const DOCS_DIR = join(__dirname, '..');
 const OUTPUT_DIR = join(DOCS_DIR, 'public', 'data');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'releases.json');
 
-const REPO = 'alvarodms/agentoak';
+const REPO = process.env.GITHUB_REPOSITORY || 'alvarodms/agentoak';
 const API_URL = `https://api.github.com/repos/${REPO}/releases?per_page=5`;
 
+async function fileExists(path) {
+  try { await access(path); return true; } catch { return false; }
+}
+
 async function main() {
+  if (await fileExists(OUTPUT_FILE)) {
+    console.log(`✔ ${OUTPUT_FILE} already exists — skipping fetch`);
+    return;
+  }
+
   let releases = [];
 
+  const headers = { 'Accept': 'application/vnd.github+json' };
+  if (process.env.GITHUB_TOKEN) {
+    headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
   try {
-    const res = await fetch(API_URL, {
-      headers: { 'Accept': 'application/vnd.github+json' },
-    });
+    const res = await fetch(API_URL, { headers });
 
     if (!res.ok) {
       console.warn(`⚠ GitHub API returned ${res.status} — writing empty releases`);


### PR DESCRIPTION
The docs Downloads page shows no releases because build-releases.mjs calls the GitHub API without authentication, hitting the 60 req/hour rate limit on shared GitHub Actions runner IPs.

- Add a dedicated 'Fetch release data' pipeline step in the deploy-docs job that runs build-releases.mjs with GITHUB_TOKEN (5,000 req/h)
- Use GITHUB_TOKEN for Bearer auth when the env var is set
- Use GITHUB_REPOSITORY env var for the repo slug (falls back to hardcoded default for local dev)
- Skip re-fetching if releases.json already exists (CI step pre- generates it before npm run build)

Made-with: Cursor