### PR TITLE
Fix planner failing to parse split StructuredOutput calls

### DIFF
--- a/src/agent/output-parser.ts
+++ b/src/agent/output-parser.ts
@@ -225,8 +225,17 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
         }
 
         // Capture StructuredOutput tool input as resultText (--json-schema uses this tool)
-        if (toolName === "StructuredOutput" && !resultText) {
-          resultText = JSON.stringify(input);
+        // Merge all StructuredOutput inputs — Claude sometimes splits across multiple calls
+        if (toolName === "StructuredOutput") {
+          try {
+            const existing = resultText ? JSON.parse(resultText) : {};
+            Object.assign(existing, input);
+            resultText = JSON.stringify(existing);
+          } catch {
+            if (!resultText) {
+              resultText = JSON.stringify(input);
+            }
+          }
         }
       }
 

--- a/src/cycle/planner.ts
+++ b/src/cycle/planner.ts
@@ -118,17 +118,22 @@ export function parsePlanResult(result: ClaudeCodeResult): CyclePlan {
     }
   }
 
+  // Fallback: merge ALL StructuredOutput inputs (Claude sometimes splits across multiple calls)
+  if (!parsed) {
+    const merged: PlanJson = {};
+    for (const action of result.actions) {
+      if (action.tool === "StructuredOutput" && action.input) {
+        Object.assign(merged, action.input as PlanJson);
+      }
+    }
+    if (merged.mode && merged.objective) {
+      parsed = merged;
+    }
+  }
+
   // Fallback: look through action results for valid JSON
   if (!parsed) {
     for (const action of result.actions) {
-      // Check StructuredOutput tool input directly (contains the plan object)
-      if (action.tool === "StructuredOutput" && action.input) {
-        const candidate = action.input as PlanJson;
-        if (candidate?.mode && candidate?.objective) {
-          parsed = candidate;
-          break;
-        }
-      }
       if (action.result) {
         try {
           const candidate = JSON.parse(action.result) as PlanJson;


### PR DESCRIPTION
When Claude produces multiple StructuredOutput tool calls with partial
fields spread across them (e.g. gameplayDesignBrief in one call, mode/
objective/reasoning in another), the parser would only capture the first
call and fail validation. Now merges all StructuredOutput inputs in both
the output parser and plan parser, fixing the "Could not parse structured
plan from CLI output" error that caused cycles to fail even after retries.

https://claude.ai/code/session_01TqvxpdH1YLaMe4SojFUMcw