### PR TITLE
feat: ensure Producer captures Tech Lead engineering suggestions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,15 @@ You are building a complete ROM hack — not just making isolated tweaks. Every 
 - **Use "planning" mode** to develop comprehensive game design documents in strategy-notes.md when you need to think through a major system (encounter design, difficulty curve, story beats, regional themes).
 - **Use "feature" mode** when implementing multi-file changes that transform a game system.
 - **Use "research" mode** when you need deep understanding of a system before a major feature — not as a default safe choice.
+- **Use "refactor" mode** when the tech debt backlog (`memory/tech-debt-backlog.md`) shows recurring friction that slows down content work. Engineering investments — tooling, abstractions, config-driven patterns — are **force multipliers** for content delivery, not distractions from it.
 
 Don't play it safe. The goal is a ROM hack with a strong creative identity, not a collection of minor data edits.
+
+### Engineering as a Content Accelerator
+
+Engineering investments that reduce the file-touch count for common operations (like adding new species, modifying encounter tables, or editing trainer rosters) are as valuable as content work — they compound across every future cycle. A cycle spent creating a helper or extracting data into config saves time on every future content cycle.
+
+Review `memory/tech-debt-backlog.md` periodically. If an engineering investment has been deferred for 5+ cycles and the underlying friction keeps appearing, it's time to act on it.
 
 ## Safety Rules
 
@@ -104,6 +111,7 @@ You have persistent memory files in `memory/` (markdown format):
 | `strategy-notes.md` | Ideas, plans, high-level strategies for the ROM hack |
 | `project-facts.md` | Build system details, tool versions, configuration notes |
 | `pokemon-knowledge.md` | **Index only.** Research findings from the Pokémon Specialist — links to per-topic files in `memory/pokemon-knowledge/` |
+| `tech-debt-backlog.md` | Engineering investment opportunities proposed by the Tech Lead across cycles. Review periodically — persistent items signal recurring friction worth addressing. |
 
 These memories persist across cycles. **Update them as you learn.** They are your most valuable resource — they let you build on previous work instead of starting from scratch.
 
@@ -129,6 +137,7 @@ Memory files are your most critical resource — but only if they stay **concise
 | `project-facts.md` | 80 lines | Should rarely grow — only add genuinely new infra facts |
 | `pokemon-knowledge.md` (index) | 30 lines | One row per topic; never add research content here |
 | `pokemon-knowledge/*.md` (each file) | 60 lines | Trim or remove when findings are outdated or superseded |
+| `tech-debt-backlog.md` | 50 lines | Mark completed items as `done`, remove items older than 20 cycles that were never acted on |
 
 **Every 10 cycles**, do a memory maintenance pass at the start of your cycle:
 1. Check line counts of all memory files

--- a/src/agent/prompt-sections.ts
+++ b/src/agent/prompt-sections.ts
@@ -77,6 +77,7 @@ export function formatMemoryFilesSection(extraFiles?: string[]): string {
     "`memory/codebase-facts.md` — discovered facts about the pokeemerald codebase",
     "`memory/failure-patterns.md` — build failures encountered and their solutions",
     "`memory/project-facts.md` — build system details and configuration notes",
+    "`memory/tech-debt-backlog.md` — accumulated engineering investment opportunities proposed by the Tech Lead across cycles (tooling, abstractions, config-driven patterns that would accelerate future content work)",
   ];
   if (extraFiles) {
     base.push(...extraFiles);

--- a/src/cycle/planner.ts
+++ b/src/cycle/planner.ts
@@ -21,6 +21,8 @@ export interface CyclePlan {
   implementationPlan: string;
   /** Optional brief for the Gameplay Designer agent. When set, Phase 1.5 spawns a specialist to produce detailed gameplay specs. For large tasks, the designer can internally parallelize using Agent Teams. */
   gameplayDesignBrief?: string;
+  /** Optional engineering investment recommended by the Tech Lead. Captured even when the cycle's main objective is content work, so it can be persisted in the tech debt backlog for future cycles. */
+  engineeringInvestment?: string;
   issueActions: IssueAction[];
   helpRequests: HelpRequest[];
 }
@@ -49,6 +51,10 @@ export const CYCLE_PLAN_SCHEMA: Record<string, unknown> = {
     gameplayDesignBrief: {
       type: "string",
       description: "Optional brief for the Gameplay Designer agent. Set this when the cycle involves gameplay changes (trainer teams, wild encounters, difficulty tuning, etc.). The Gameplay Designer has access to Pokédex MCP tools and will produce detailed, data-driven specifications. When you set this, your implementationPlan should focus on implementation steps (which files to modify, patterns to follow) rather than exact gameplay values — the Gameplay Designer will provide those.",
+    },
+    engineeringInvestment: {
+      type: "string",
+      description: "Optional engineering investment opportunity identified by the Tech Lead or your own analysis. Capture it here even if this cycle focuses on content — it will be persisted in the tech debt backlog so future cycles can act on it. Examples: 'Extract wild encounter tables into a JSON config so adding species to a route is a 1-file edit instead of 3', 'Create a helper script that auto-generates species constant boilerplate'.",
     },
     issueActions: {
       type: "array",
@@ -104,6 +110,7 @@ export function parsePlanResult(result: ClaudeCodeResult): CyclePlan {
     reasoning?: string;
     implementationPlan?: string;
     gameplayDesignBrief?: string;
+    engineeringInvestment?: string;
     issueActions?: IssueAction[];
     helpRequests?: HelpRequest[];
   }
@@ -179,6 +186,7 @@ export function parsePlanResult(result: ClaudeCodeResult): CyclePlan {
       reasoning: parsed.reasoning,
       implementationPlan: parsed.implementationPlan ?? "",
       gameplayDesignBrief: parsed.gameplayDesignBrief || undefined,
+      engineeringInvestment: parsed.engineeringInvestment || undefined,
       issueActions,
       helpRequests,
     };

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -32,9 +32,32 @@ import type { ValidationResult } from "../reflection/validator.js";
 import { fetchNewCommunityIssues, formatIssuesForPrompt, executeIssueActions, createHelpRequest, readIssueBacklog, updateIssueBacklog, addIssueToBacklog, getStaleBacklogIssues, postIssueClosingComment, postIssuePartialDeliveryComment } from "../github/issues.js";
 import { closeIssue, addLabelsToIssue, AGENT_LABELS } from "../github/client.js";
 import { cycleLogger } from "../utils/logger.js";
-import { PROJECT_ROOT, ARTIFACTS_DIR } from "../utils/paths.js";
+import { PROJECT_ROOT, ARTIFACTS_DIR, MEMORY_DIR } from "../utils/paths.js";
 import { createCycleRelease } from "../release/release.js";
 import type { TokenUsage } from "../memory/types.js";
+
+const TECH_DEBT_BACKLOG_PATH = path.join(MEMORY_DIR, "tech-debt-backlog.md");
+
+/** Append an engineering investment to the persistent tech debt backlog. */
+function persistEngineeringInvestment(
+  cycleNumber: number,
+  investment: string,
+): void {
+  const header = "# Tech Debt Backlog\n\nEngineering investment opportunities identified by the Tech Lead across cycles.\nThe Producer should review this list when planning — picking up even one item per few cycles compounds over time.\n\n| Cycle | Investment | Status |\n|-------|-----------|--------|\n";
+
+  let content: string;
+  if (fs.existsSync(TECH_DEBT_BACKLOG_PATH)) {
+    content = fs.readFileSync(TECH_DEBT_BACKLOG_PATH, "utf-8");
+  } else {
+    fs.mkdirSync(MEMORY_DIR, { recursive: true });
+    content = header;
+  }
+
+  // Append the new investment as a table row
+  const sanitized = investment.replace(/\|/g, "—").replace(/\n/g, " ").trim();
+  content += `| ${cycleNumber} | ${sanitized} | pending |\n`;
+  fs.writeFileSync(TECH_DEBT_BACKLOG_PATH, content, "utf-8");
+}
 
 const MAX_BUILD_FIX_ATTEMPTS = 3;
 const MAX_COMMIT_FIX_ATTEMPTS = 3;
@@ -455,6 +478,12 @@ export async function runCycle(): Promise<void> {
 
     // Record the chosen mode in history so future planners can see the pattern
     updateCycleModeHistory(plan.mode);
+
+    // Persist any engineering investment to the tech debt backlog
+    if (plan.engineeringInvestment) {
+      persistEngineeringInvestment(cycleNumber, plan.engineeringInvestment);
+      log.info(`  Engineering investment captured: ${plan.engineeringInvestment.slice(0, 100)}...`);
+    }
 
     // ── Phase 1.5: Gameplay Design (conditional — only when Producer sets a brief) ──
     let activePlan: CyclePlan = plan;

--- a/src/cycle/team-planner.ts
+++ b/src/cycle/team-planner.ts
@@ -66,6 +66,8 @@ function buildMemoSection(
 
 Before making your decision, consider these perspectives from your advisory team. You may agree or disagree with any advisor — the final decision is yours. In your \`reasoning\` field, briefly note which perspectives influenced your decision.
 
+**Engineering investments**: If the Technical Lead proposes an engineering improvement (tooling, abstractions, config-driven patterns), you must either (a) incorporate it into this cycle's objective, (b) capture it in the \`engineeringInvestment\` field so it is preserved for a future cycle, or (c) explain in your \`reasoning\` why it is not worth pursuing. Do not silently ignore engineering suggestions — they compound across cycles.
+
 ${parts.join("\n\n")}`;
 }
 
@@ -147,6 +149,9 @@ Decide: What mode should this cycle use, and what should the objective be?
 
 If previous cycles had build failures, consider "repair".
 
+## Engineering Investment (optional field)
+
+Even when the main objective is content work, capture any valuable engineering improvement opportunity in the \`engineeringInvestment\` field. This is persisted in a tech debt backlog across cycles, building a visible record of deferred infrastructure work. Engineering investments that reduce file-touch counts or automate repetitive operations accelerate all future content cycles — they are not in opposition to the creative vision, they are force multipliers for it.
 
 ${formatImplementationPlanGuidance()}
 


### PR DESCRIPTION
The Producer agent was structurally ignoring Tech Lead engineering
improvement suggestions because: (1) 3-of-4 advisors push content,
(2) no schema field existed to capture engineering investments, and
(3) CLAUDE.md framed success entirely as game content.

Changes:
- Add `engineeringInvestment` field to CyclePlan interface + JSON schema
- Persist investments to memory/tech-debt-backlog.md across cycles
- Update Producer prompt to require explicit handling of Tech Lead advice
  (incorporate, capture, or explain why not — no silent ignoring)
- Add tech-debt-backlog.md to memory file lists and maintenance budgets
- Reframe CLAUDE.md to position engineering as a content accelerator

https://claude.ai/code/session_01Fz1ziGKiYfxNG6u4aFdgmm