### PR TITLE
Add multi-item GitHub issue handling support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,6 +283,7 @@ Each outcome object has these fields:
 | `status` | yes | `"complete"` or `"partial"` | Was the ask fully implemented? |
 | `decision` | if partial | `"defer"` or `"reject"` | What to do with the remaining work |
 | `reason` | if partial | string | Plain-English explanation posted as a comment on the issue |
+| `item_outcomes` | if multi-item | array | Per-item outcomes for issues with multiple distinct asks (see below) |
 
 **Rules:**
 - `"complete"` — the issue's ask was fully implemented. The runner will close the issue.
@@ -306,6 +307,24 @@ Each outcome object has these fields:
 ```json
 {"number": 7, "status": "partial", "decision": "reject", "reason": "Implemented the sprite recolour as asked. The second part of the request (adding new animations) is out of scope for the current project direction."}
 ```
+
+**Example — multi-item issue with per-item outcomes:**
+```json
+{
+  "number": 42,
+  "status": "partial",
+  "decision": "defer",
+  "reason": "Completed 2 of 4 items. Remaining items deferred.",
+  "item_outcomes": [
+    {"label": "Dragon Rage bug", "status": "complete"},
+    {"label": "Lapras duplication", "status": "complete"},
+    {"label": "Add Emboar", "status": "partial", "decision": "reject", "reason": "Out of scope for current gen"},
+    {"label": "Level curve", "status": "not-started", "decision": "defer", "reason": "Needs a dedicated tuning cycle"}
+  ]
+}
+```
+
+Each `item_outcomes` entry has: `label` (matching the label from planning), `status` (`"complete"`, `"partial"`, or `"not-started"`), and optionally `decision` and `reason`. The issue is only closed when ALL items are resolved (complete or rejected).
 
 ## Public Communication
 
@@ -342,6 +361,14 @@ Agent Oak can interact with the community through GitHub issues. At the start of
 | `agent-rejected` | Not aligned with the project direction |
 | `agent-needs-info` | You asked the author a clarifying question |
 | `agent-help-request` | Issues YOU create when you need human input |
+
+### Multi-Item Issues
+
+Some community issues contain multiple distinct asks (e.g., several bugs plus a feature request). When you encounter these during planning, use the `items` array in your `issueActions` entry to give each item its own action and response. The runner will format your response as a checklist so each contributor knows exactly what happened to each part of their issue.
+
+Set the top-level `action` to the dominant one: `accept` if any item is accepted, `defer` if all are deferred, `reject` if all are rejected. Set `partial` to `true` if any item requires multi-cycle work. For single-ask issues, omit `items` entirely.
+
+During CYCLE_COMPLETE, report per-item outcomes using the `item_outcomes` array within `issue_outcomes`. The runner uses this to track which items are still pending and only closes the issue when all items are resolved.
 
 ### Security Rules — CRITICAL
 

--- a/src/agent/output-parser.ts
+++ b/src/agent/output-parser.ts
@@ -15,11 +15,21 @@
  *   cycle, or "reject" to close it without completing the work) and `reason`
  *   (a plain-English explanation posted as a comment on the issue).
  */
+/** Per-item delivery outcome for multi-item issues. */
+export interface IssueItemOutcome {
+  label: string;
+  status: "complete" | "partial" | "not-started";
+  decision?: "defer" | "reject";
+  reason?: string;
+}
+
 export interface IssueOutcome {
   number: number;
   status: "complete" | "partial";
   decision?: "defer" | "reject";
   reason?: string;
+  /** Optional per-item outcomes for multi-item issues. */
+  itemOutcomes?: IssueItemOutcome[];
 }
 
 export interface ClaudeCodeResult {
@@ -146,13 +156,24 @@ export function parseClaudeOutput(rawOutput: string): ClaudeCodeResult {
             }
             nextSteps = parsed.next_steps ?? nextSteps;
             if (Array.isArray(parsed.issue_outcomes) && parsed.issue_outcomes.length > 0) {
-              issueOutcomes = parsed.issue_outcomes.filter(
-                (o): o is IssueOutcome =>
-                  o !== null &&
-                  typeof o === "object" &&
-                  typeof o.number === "number" &&
-                  (o.status === "complete" || o.status === "partial"),
-              );
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              issueOutcomes = (parsed.issue_outcomes as any[])
+                .filter(
+                  (o) =>
+                    o !== null &&
+                    typeof o === "object" &&
+                    typeof o.number === "number" &&
+                    (o.status === "complete" || o.status === "partial"),
+                )
+                .map((o): IssueOutcome => ({
+                  number: o.number as number,
+                  status: o.status as "complete" | "partial",
+                  decision: o.decision as "defer" | "reject" | undefined,
+                  reason: o.reason as string | undefined,
+                  itemOutcomes: Array.isArray(o.item_outcomes)
+                    ? (o.item_outcomes as IssueItemOutcome[])
+                    : undefined,
+                }));
             }
             if (parsed.version_bump === "major" || parsed.version_bump === "minor") {
               versionBump = parsed.version_bump;

--- a/src/agent/prompt-sections.ts
+++ b/src/agent/prompt-sections.ts
@@ -36,7 +36,7 @@ export function formatIssueSection(issueContext: string): string {
 /** Build the "Deferred Issue Backlog" section (returns empty string if absent). */
 export function formatBacklogSection(
   issueBacklog: string,
-  staleIssues?: Array<{ issueNumber: number; title: string; deferredAtCycle: number }>,
+  staleIssues?: Array<{ issueNumber: number; title: string; deferredAtCycle: number; pendingItems?: string[] }>,
 ): string {
   const hasBacklog = !!issueBacklog;
   const hasStale = staleIssues && staleIssues.length > 0;
@@ -49,9 +49,13 @@ export function formatBacklogSection(
   }
 
   if (hasStale) {
-    const staleLines = staleIssues.map(
-      (i) => `- #${i.issueNumber}: ${i.title} (deferred since cycle ${i.deferredAtCycle})`,
-    ).join("\n");
+    const staleLines = staleIssues.map((i) => {
+      let line = `- #${i.issueNumber}: ${i.title} (deferred since cycle ${i.deferredAtCycle})`;
+      if (i.pendingItems && i.pendingItems.length > 0) {
+        line += ` — Pending items: ${i.pendingItems.join(", ")}`;
+      }
+      return line;
+    }).join("\n");
     section += `\n### Stale Issues (deferred 10+ cycles)\n\nThese issues have been sitting in the backlog for a long time. Please re-evaluate each one and include it in \`issueActions\`:\n- **accept**: Pick it up this cycle\n- **reject**: It no longer aligns with the project direction — close it with a reason\n- **defer**: Still worth keeping — provide a brief justification for why\n\n${staleLines}\n`;
   }
 
@@ -150,6 +154,7 @@ You have access to a **Gameplay Designer** agent that can produce detailed, data
 export function formatPlannerClosingInstructions(): string {
   return `**Issue handling rules:**
 - **New community issues**: Review each one and include your decisions in the \`issueActions\` array. You have full freedom to accept, defer, reject, or ask for more info.
+- **Multi-item issues**: If an issue contains multiple distinct asks (bugs + features, etc.), use the \`items\` array within your issueAction to give each item its own action and response. Set the top-level \`action\` to the dominant one (accept if any is accepted, defer if all deferred, reject if all rejected). For single-ask issues, omit \`items\`.
 - **Regular backlog issues**: Do NOT include them in \`issueActions\` — they are carried forward automatically. Only include a backlog issue if you want to **accept** it this cycle.
 - **Stale backlog issues** (marked in the "Stale Issues" section): You MUST re-evaluate each one and include it in \`issueActions\` with accept, reject, or defer.
 
@@ -172,7 +177,7 @@ export interface PlannerContextParams {
   modeHistorySummary: string;
   issueContext: string;
   issueBacklog: string;
-  staleIssues?: Array<{ issueNumber: number; title: string; deferredAtCycle: number }>;
+  staleIssues?: Array<{ issueNumber: number; title: string; deferredAtCycle: number; pendingItems?: string[] }>;
   extraMemoryFiles?: string[];
 }
 

--- a/src/cycle/planner.ts
+++ b/src/cycle/planner.ts
@@ -66,15 +66,34 @@ export const CYCLE_PLAN_SCHEMA: Record<string, unknown> = {
           action: {
             type: "string",
             enum: ["accept", "defer", "reject", "need-info"],
-            description: "What to do with the issue",
+            description: "What to do with the issue. For multi-item issues, use the dominant action: accept if any item is accepted, defer if all deferred, reject if all rejected.",
           },
           response: {
             type: "string",
-            description: "A brief, friendly response to post as a comment on the issue",
+            description: "A brief, friendly response to post as a comment on the issue. For multi-item issues, this is a summary — per-item detail goes in items[].",
           },
           partial: {
             type: "boolean",
-            description: "Set to true when accepting a complex issue that will require multiple cycles to fully implement. The issue will stay open and remain in the backlog so you can continue working on it next cycle. Only valid with action 'accept'.",
+            description: "Set to true when accepting a complex issue that will require multiple cycles to fully implement. The issue will stay open and remain in the backlog so you can continue working on it next cycle. Only valid with action 'accept'. For multi-item issues, set this if ANY item is partial.",
+          },
+          items: {
+            type: "array",
+            description: "Per-item breakdown when an issue contains multiple distinct asks (bugs, feature requests, balance complaints, etc.). Each item gets its own action and response. Omit entirely for single-ask issues.",
+            items: {
+              type: "object",
+              properties: {
+                label: { type: "string", description: "Short name for this item (e.g., 'Dragon Rage damage bug')" },
+                action: {
+                  type: "string",
+                  enum: ["accept", "defer", "reject", "need-info"],
+                  description: "What to do with this specific item",
+                },
+                response: { type: "string", description: "Brief response for this specific item" },
+                partial: { type: "boolean", description: "This item needs multi-cycle work" },
+              },
+              required: ["label", "action", "response"],
+              additionalProperties: false,
+            },
           },
         },
         required: ["issueNumber", "action", "response"],

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -12,7 +12,7 @@ import {
   buildCommitFixPrompt,
 } from "../agent/prompts.js";
 import { runClaudeCode } from "../agent/claude-cli.js";
-import type { ClaudeCodeResult } from "../agent/output-parser.js";
+import type { ClaudeCodeResult, IssueOutcome } from "../agent/output-parser.js";
 import type { ActionRecord } from "../agent/output-parser.js";
 import { runReflection } from "../reflection/reflect.js";
 import { runBuild, saveBuildLog } from "../repo/build.js";
@@ -669,7 +669,15 @@ export async function runCycle(): Promise<void> {
         }
         const outcome = outcomeMap.get(issueNumber);
         if (outcome?.status === "partial") {
-          if ((outcome.decision ?? "defer") === "reject") {
+          // For multi-item issues, check if there are remaining items
+          const resolution = resolveMultiItemOutcome(outcome);
+          if (resolution.canClose) {
+            if (resolution.closingReason === "not_planned") {
+              rejectNumbers.push(issueNumber);
+            } else {
+              closingNumbers.push(issueNumber);
+            }
+          } else if ((outcome.decision ?? "defer") === "reject") {
             rejectNumbers.push(issueNumber);
           } else {
             deferNumbers.push(issueNumber);
@@ -685,7 +693,9 @@ export async function runCycle(): Promise<void> {
         log.info(`  Closing ${closingNumbers.length} completed issue(s)...`);
         const closingSummary = reflection.cycleSummary || plan.objective;
         for (const issueNumber of closingNumbers) {
-          await postIssueClosingComment(issueNumber, closingSummary);
+          const outcome = outcomeMap.get(issueNumber);
+          const closingComment = formatClosingCommentWithItems(closingSummary, outcome);
+          await postIssueClosingComment(issueNumber, closingComment);
           await closeIssue(issueNumber, "completed");
         }
       }
@@ -696,10 +706,23 @@ export async function runCycle(): Promise<void> {
         for (const issueNumber of deferNumbers) {
           const outcome = outcomeMap.get(issueNumber)!;
           const reason = outcome.reason ?? "This cycle's work partially addressed this issue.";
-          await postIssuePartialDeliveryComment(issueNumber, reason, "defer");
+          const resolution = resolveMultiItemOutcome(outcome);
+          const partialComment = formatPartialCommentWithItems(reason, outcome);
+          await postIssuePartialDeliveryComment(issueNumber, partialComment, "defer");
           await addLabelsToIssue(issueNumber, [AGENT_LABELS.deferred]);
-          // Re-add to backlog so it surfaces in a future cycle
+          // Re-add to backlog with remaining items tracked
           addIssueToBacklog(issueNumber, `Issue #${issueNumber}`, cycleNumber);
+          // If there are remaining items, update the backlog entry with pending items
+          if (resolution.remainingItems.length > 0) {
+            const { parseBacklogEntries } = await import("../github/issues.js");
+            const entries = parseBacklogEntries();
+            const entry = entries.find((e) => e.issueNumber === issueNumber);
+            if (entry) {
+              entry.pendingItems = resolution.remainingItems;
+              // Re-write backlog with updated pending items
+              addIssueToBacklog(issueNumber, entry.title, cycleNumber);
+            }
+          }
         }
       }
 
@@ -709,7 +732,8 @@ export async function runCycle(): Promise<void> {
         for (const issueNumber of rejectNumbers) {
           const outcome = outcomeMap.get(issueNumber)!;
           const reason = outcome.reason ?? "This cycle's work only partially addressed this issue, and the remaining work will not be pursued.";
-          await postIssuePartialDeliveryComment(issueNumber, reason, "reject");
+          const rejectComment = formatPartialCommentWithItems(reason, outcome);
+          await postIssuePartialDeliveryComment(issueNumber, rejectComment, "reject");
           await addLabelsToIssue(issueNumber, [AGENT_LABELS.rejected]);
           await closeIssue(issueNumber, "not_planned");
         }
@@ -787,4 +811,80 @@ export async function runCycle(): Promise<void> {
 
     throw err;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-item issue outcome helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve whether a multi-item issue can be closed, and which items remain.
+ * For single-item issues (no itemOutcomes), falls through to existing behavior.
+ */
+function resolveMultiItemOutcome(outcome: IssueOutcome): {
+  canClose: boolean;
+  remainingItems: string[];
+  closingReason: "completed" | "not_planned";
+} {
+  if (!outcome.itemOutcomes || outcome.itemOutcomes.length === 0) {
+    // Single-item fallback
+    return {
+      canClose: outcome.status === "complete" || outcome.decision === "reject",
+      remainingItems: [],
+      closingReason: outcome.decision === "reject" ? "not_planned" : "completed",
+    };
+  }
+
+  const remaining = outcome.itemOutcomes.filter(
+    (i) =>
+      i.status === "not-started" ||
+      (i.status === "partial" && (i.decision ?? "defer") === "defer"),
+  );
+
+  const allRejected = outcome.itemOutcomes.every(
+    (i) => i.decision === "reject",
+  );
+
+  return {
+    canClose: remaining.length === 0,
+    remainingItems: remaining.map((i) => i.label),
+    closingReason: allRejected ? "not_planned" : "completed",
+  };
+}
+
+/**
+ * Format a closing comment with per-item detail for multi-item issues.
+ * Falls back to plain summary for single-item issues.
+ */
+function formatClosingCommentWithItems(summary: string, outcome?: IssueOutcome): string {
+  if (!outcome?.itemOutcomes || outcome.itemOutcomes.length === 0) {
+    return summary;
+  }
+
+  const itemLines = outcome.itemOutcomes.map((item) => {
+    if (item.status === "complete") return `- ✅ **${item.label}** — Done`;
+    if (item.decision === "reject") return `- ❌ **${item.label}** — Declined${item.reason ? `: ${item.reason}` : ""}`;
+    return `- ⏳ **${item.label}** — ${item.reason ?? "Pending"}`;
+  });
+
+  return `${summary}\n\n**Item breakdown:**\n${itemLines.join("\n")}`;
+}
+
+/**
+ * Format a partial delivery comment with per-item detail for multi-item issues.
+ * Falls back to plain reason for single-item issues.
+ */
+function formatPartialCommentWithItems(reason: string, outcome: IssueOutcome): string {
+  if (!outcome.itemOutcomes || outcome.itemOutcomes.length === 0) {
+    return reason;
+  }
+
+  const itemLines = outcome.itemOutcomes.map((item) => {
+    if (item.status === "complete") return `- ✅ **${item.label}** — Done`;
+    if (item.status === "not-started") return `- ⬜ **${item.label}** — Not started${item.reason ? `: ${item.reason}` : ""}`;
+    if (item.decision === "reject") return `- ❌ **${item.label}** — Declined${item.reason ? `: ${item.reason}` : ""}`;
+    return `- ⏳ **${item.label}** — Partially done${item.reason ? `: ${item.reason}` : ""}`;
+  });
+
+  return `${reason}\n\n**Item breakdown:**\n${itemLines.join("\n")}`;
 }

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -33,14 +33,29 @@ export interface GitHubComment {
   createdAt: string;
 }
 
+/** A per-item action within a multi-item issue */
+export interface IssueActionItem {
+  /** Short label identifying the item (e.g., "Dragon Rage damage bug") */
+  label: string;
+  action: "accept" | "defer" | "reject" | "need-info";
+  response: string;
+  /** When true, this item requires multiple cycles to complete. */
+  partial?: boolean;
+}
+
 /** An action the planner decided to take on a community issue */
 export interface IssueAction {
   issueNumber: number;
+  /** Overall action for the issue. For multi-item issues, this is the "dominant" action:
+   *  accept if any item is accepted, defer if all deferred, reject if all rejected. */
   action: "accept" | "defer" | "reject" | "need-info";
   response: string;
   /** When true, the issue requires multiple cycles to complete. The issue stays open and
    *  remains in the backlog for future cycles. Only meaningful with action "accept". */
   partial?: boolean;
+  /** Optional per-item breakdown for issues containing multiple distinct asks.
+   *  When present, each item gets its own action and response. */
+  items?: IssueActionItem[];
 }
 
 /** A help request the agent wants to raise */

--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -18,7 +18,7 @@ import {
   AGENT_LABELS,
   COMMUNITY_LABELS,
 } from "./client.js";
-import type { GitHubIssue, IssueAction, HelpRequest } from "./client.js";
+import type { GitHubIssue, IssueAction, IssueActionItem, HelpRequest } from "./client.js";
 import { logger } from "../utils/logger.js";
 import { MEMORY_DIR } from "../utils/paths.js";
 
@@ -30,13 +30,19 @@ export interface BacklogEntry {
   title: string;
   /** The cycle number when this issue was deferred. 0 if unknown (legacy entries). */
   deferredAtCycle: number;
+  /** For multi-item issues: labels of items still pending. Omitted for single-item issues. */
+  pendingItems?: string[];
 }
 
-const BACKLOG_LINE_RE = /^- #(\d+):\s*(.+?)(?:\s*\(deferred: cycle (\d+)\))?$/;
+const BACKLOG_LINE_RE = /^- #(\d+):\s*(.+?)(?:\s*\(deferred: cycle (\d+)\))?(?:\s*\|\s*pending:\s*(.+))?$/;
 
 /** Format a single backlog entry as a markdown line. */
 function formatBacklogLine(entry: BacklogEntry): string {
-  return `- #${entry.issueNumber}: ${entry.title} (deferred: cycle ${entry.deferredAtCycle})`;
+  let line = `- #${entry.issueNumber}: ${entry.title} (deferred: cycle ${entry.deferredAtCycle})`;
+  if (entry.pendingItems && entry.pendingItems.length > 0) {
+    line += ` | pending: ${entry.pendingItems.join("; ")}`;
+  }
+  return line;
 }
 
 /**
@@ -50,10 +56,14 @@ export function parseBacklogEntries(): BacklogEntry[] {
     for (const line of fs.readFileSync(BACKLOG_FILE, "utf-8").split("\n")) {
       const match = line.match(BACKLOG_LINE_RE);
       if (match) {
+        const pendingItems = match[4]
+          ? match[4].split(";").map((s) => s.trim()).filter(Boolean)
+          : undefined;
         entries.push({
           issueNumber: parseInt(match[1], 10),
           title: match[2].trim(),
           deferredAtCycle: match[3] ? parseInt(match[3], 10) : 0,
+          pendingItems,
         });
       }
     }
@@ -127,21 +137,50 @@ export function updateIssueBacklog(
 
   let changed = false;
   for (const action of actions) {
+    // For multi-item issues, compute which items are deferred
+    const deferredItemLabels = action.items
+      ?.filter((item) => item.action === "defer" || (item.action === "accept" && item.partial))
+      .map((item) => item.label);
+
     if (action.action === "defer") {
+      const title = issueMap.get(action.issueNumber)?.title ?? existing.get(action.issueNumber)?.title ?? "Unknown";
       if (!existing.has(action.issueNumber)) {
         // New deferral
-        const title = issueMap.get(action.issueNumber)?.title ?? "Unknown";
-        existing.set(action.issueNumber, { issueNumber: action.issueNumber, title, deferredAtCycle: cycleNumber });
+        existing.set(action.issueNumber, {
+          issueNumber: action.issueNumber,
+          title,
+          deferredAtCycle: cycleNumber,
+          pendingItems: deferredItemLabels?.length ? deferredItemLabels : undefined,
+        });
         changed = true;
       } else if (staleIssueNumbers?.has(action.issueNumber)) {
         // Re-deferring a stale issue — reset cycle counter
         const entry = existing.get(action.issueNumber)!;
-        existing.set(action.issueNumber, { ...entry, deferredAtCycle: cycleNumber });
+        existing.set(action.issueNumber, {
+          ...entry,
+          deferredAtCycle: cycleNumber,
+          pendingItems: deferredItemLabels?.length ? deferredItemLabels : entry.pendingItems,
+        });
         changed = true;
       }
-    } else if (action.action === "accept" || action.action === "reject") {
-      // Keep in backlog when it's a partial (multi-cycle) accept — the work isn't done yet
-      if (existing.has(action.issueNumber) && !(action.action === "accept" && action.partial)) {
+    } else if (action.action === "accept") {
+      if (action.items && action.items.length > 0 && deferredItemLabels && deferredItemLabels.length > 0) {
+        // Multi-item: some items accepted, some deferred — track deferred items in backlog
+        const title = issueMap.get(action.issueNumber)?.title ?? existing.get(action.issueNumber)?.title ?? "Unknown";
+        existing.set(action.issueNumber, {
+          issueNumber: action.issueNumber,
+          title,
+          deferredAtCycle: cycleNumber,
+          pendingItems: deferredItemLabels,
+        });
+        changed = true;
+      } else if (existing.has(action.issueNumber) && !action.partial) {
+        // Single-item accept (not partial) — remove from backlog
+        existing.delete(action.issueNumber);
+        changed = true;
+      }
+    } else if (action.action === "reject") {
+      if (existing.has(action.issueNumber)) {
         existing.delete(action.issueNumber);
         changed = true;
       }
@@ -258,6 +297,8 @@ For each issue, decide one of:
 
 Include your decisions in the \`issueActions\` array in your response.
 
+If an issue contains **multiple distinct asks** (e.g., several bugs, a mix of bugs and feature requests), use the \`items\` array within your issueAction to give each item its own action and response. Set the top-level \`action\` to the dominant one (accept if any item is accepted). For single-ask issues, omit \`items\` entirely.
+
 ${formatted.join("\n\n---\n\n")}`;
 }
 
@@ -279,6 +320,35 @@ const ACTION_PREFIX_MAP: Record<IssueAction["action"], string> = {
 
 const PARTIAL_ACCEPT_PREFIX = "🤖 **Agent Oak — In Progress**\n\n";
 
+/** Action emoji for multi-item comment formatting */
+const ITEM_ACTION_EMOJI: Record<IssueActionItem["action"], string> = {
+  accept: "✅ Accepted",
+  defer: "⏳ Deferred",
+  reject: "❌ Declined",
+  "need-info": "❓ Need Info",
+};
+
+/**
+ * Format a multi-item issue response as a checklist-style comment.
+ * Each item gets its own row with action indicator and response.
+ */
+function formatMultiItemComment(items: IssueActionItem[], overallResponse: string): string {
+  const rows = items.map((item) => {
+    const actionStr = item.partial
+      ? `${ITEM_ACTION_EMOJI[item.action]} (multi-cycle)`
+      : ITEM_ACTION_EMOJI[item.action];
+    return `| **${item.label}** | ${actionStr} | ${item.response} |`;
+  });
+
+  return `🤖 **Agent Oak — Review**
+
+${overallResponse}
+
+| Item | Decision | Notes |
+|------|----------|-------|
+${rows.join("\n")}`;
+}
+
 /**
  * Execute the planner's decisions on community issues.
  *
@@ -294,25 +364,33 @@ export async function executeIssueActions(actions: IssueAction[]): Promise<void>
   for (const action of actions) {
     try {
       // Post the agent's response as a comment
-      const prefix = (action.action === "accept" && action.partial)
-        ? PARTIAL_ACCEPT_PREFIX
-        : (ACTION_PREFIX_MAP[action.action] ?? "");
-      await commentOnIssue(action.issueNumber, prefix + action.response);
+      if (action.items && action.items.length > 0) {
+        // Multi-item issue: checklist-style comment
+        const body = formatMultiItemComment(action.items, action.response);
+        await commentOnIssue(action.issueNumber, body);
+      } else {
+        // Single-item issue: existing format
+        const prefix = (action.action === "accept" && action.partial)
+          ? PARTIAL_ACCEPT_PREFIX
+          : (ACTION_PREFIX_MAP[action.action] ?? "");
+        await commentOnIssue(action.issueNumber, prefix + action.response);
+      }
 
-      // Add the action label + reviewed label
+      // Add the action label + reviewed label (based on dominant action)
       const actionLabel = ACTION_LABEL_MAP[action.action];
       const labels: string[] = [AGENT_LABELS.reviewed];
       if (actionLabel) labels.push(actionLabel);
 
       await addLabelsToIssue(action.issueNumber, labels);
 
-      // Close rejected issues immediately — the decision is final
+      // Close rejected issues immediately — only if ALL items are rejected
+      // (for multi-item issues, action === "reject" means every item was rejected)
       if (action.action === "reject") {
         await closeIssue(action.issueNumber, "not_planned");
       }
 
       logger.info(
-        `Issue #${action.issueNumber}: ${action.action} — labels: [${labels.join(", ")}]`,
+        `Issue #${action.issueNumber}: ${action.action}${action.items ? ` (${action.items.length} items)` : ""} — labels: [${labels.join(", ")}]`,
       );
     } catch (err) {
       logger.error(


### PR DESCRIPTION
Issues containing multiple distinct asks (bugs, features, balance complaints)
can now be broken down into individual items, each with its own action and
tracking. The planner uses an optional `items` array in issueActions, the
runner formats checklist-style comments, and closure/backlog logic tracks
per-item state so issues only close when all items are resolved.

https://claude.ai/code/session_01Bh3DTCbRywR2WAKBkuuidj