### PR TITLE
Show plan results for planning cycles on docs website

### DIFF
--- a/docs/build-scripts/build-journals.mjs
+++ b/docs/build-scripts/build-journals.mjs
@@ -8,6 +8,7 @@
 import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DOCS_DIR = join(__dirname, '..');
@@ -62,6 +63,12 @@ function parseJournal(md, filename) {
   const nextSteps = (sections['Next Steps'] || '').trim();
   const stats = parseStats(sections['Stats'] || '');
 
+  // Plan output: first try the journal section, then fall back to git diff
+  let planOutput = (sections['Plan Output'] || '').trim();
+  if (!planOutput && mode === 'planning') {
+    planOutput = extractPlanOutputFromGit(cycle);
+  }
+
   return {
     cycle,
     date,
@@ -73,6 +80,7 @@ function parseJournal(md, filename) {
     summary,
     nextSteps,
     stats,
+    ...(planOutput ? { planOutput } : {}),
   };
 }
 
@@ -153,6 +161,37 @@ function parseStats(text) {
   if (tokensMatch) stats.tokensUsed = parseInt(tokensMatch[1].replace(/,/g, ''), 10);
 
   return Object.keys(stats).length > 0 ? stats : null;
+}
+
+/**
+ * For planning cycles without a ## Plan Output section in the journal,
+ * extract the strategy-notes additions from the git diff of that cycle's commit.
+ */
+function extractPlanOutputFromGit(cycle) {
+  try {
+    const padded = String(cycle).padStart(4, '0');
+    const hash = execSync(
+      `git log --all --format=%H --grep="cycle ${padded}" -- journal/`,
+      { cwd: ROOT, encoding: 'utf-8', timeout: 10000 },
+    ).trim().split('\n')[0];
+    if (!hash) return '';
+
+    const diff = execSync(
+      `git diff ${hash}^..${hash} -- memory/strategy-notes.md`,
+      { cwd: ROOT, encoding: 'utf-8', timeout: 10000 },
+    );
+    if (!diff) return '';
+
+    // Extract only added lines (skip diff headers like +++ and @@)
+    return diff
+      .split('\n')
+      .filter(line => line.startsWith('+') && !line.startsWith('+++'))
+      .map(line => line.slice(1))
+      .join('\n')
+      .trim();
+  } catch {
+    return '';
+  }
 }
 
 main().catch(err => {

--- a/docs/src/components/JournalCard.tsx
+++ b/docs/src/components/JournalCard.tsx
@@ -5,6 +5,159 @@ interface JournalCardProps {
   entry: JournalEntry;
 }
 
+/**
+ * Lightweight markdown renderer for plan output content.
+ * Handles headers, tables, bullet lists, and bold text.
+ */
+function MarkdownContent({ text }: { text: string }) {
+  const lines = text.split('\n');
+  const elements: JSX.Element[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Skip empty lines
+    if (!line.trim()) {
+      i++;
+      continue;
+    }
+
+    // Headers
+    if (line.startsWith('### ')) {
+      elements.push(<h6 key={i}>{formatInline(line.slice(4))}</h6>);
+      i++;
+      continue;
+    }
+    if (line.startsWith('## ')) {
+      elements.push(<h5 key={i}>{formatInline(line.slice(3))}</h5>);
+      i++;
+      continue;
+    }
+    if (line.startsWith('# ')) {
+      elements.push(<h4 key={i}>{formatInline(line.slice(2))}</h4>);
+      i++;
+      continue;
+    }
+
+    // Table: collect consecutive lines starting with |
+    if (line.startsWith('|')) {
+      const tableLines: string[] = [];
+      while (i < lines.length && lines[i].startsWith('|')) {
+        tableLines.push(lines[i]);
+        i++;
+      }
+      elements.push(<MarkdownTable key={`table-${i}`} lines={tableLines} />);
+      continue;
+    }
+
+    // Bullet list: collect consecutive lines starting with -
+    if (line.match(/^[-*]\s/)) {
+      const items: string[] = [];
+      while (i < lines.length && lines[i].match(/^[-*]\s/)) {
+        items.push(lines[i].replace(/^[-*]\s+/, ''));
+        i++;
+      }
+      elements.push(
+        <ul key={`ul-${i}`}>
+          {items.map((item, j) => (
+            <li key={j}>{formatInline(item)}</li>
+          ))}
+        </ul>,
+      );
+      continue;
+    }
+
+    // Horizontal rule
+    if (line.match(/^-{3,}$/)) {
+      elements.push(<hr key={i} />);
+      i++;
+      continue;
+    }
+
+    // Plain paragraph
+    elements.push(<p key={i}>{formatInline(line)}</p>);
+    i++;
+  }
+
+  return <>{elements}</>;
+}
+
+/** Render a markdown table from lines */
+function MarkdownTable({ lines }: { lines: string[] }) {
+  const parseRow = (line: string) =>
+    line
+      .split('|')
+      .slice(1, -1)
+      .map((cell) => cell.trim());
+
+  // Detect separator row (e.g. |---|---|)
+  const isSeparator = (line: string) => /^\|[\s:|-]+\|$/.test(line);
+
+  const headerRow = parseRow(lines[0]);
+  const hasSeparator = lines.length > 1 && isSeparator(lines[1]);
+  const dataStart = hasSeparator ? 2 : 1;
+  const dataRows = lines.slice(dataStart).filter((l) => !isSeparator(l)).map(parseRow);
+
+  return (
+    <div className="plan-table-wrapper">
+      <table>
+        {hasSeparator && (
+          <thead>
+            <tr>
+              {headerRow.map((cell, j) => (
+                <th key={j}>{formatInline(cell)}</th>
+              ))}
+            </tr>
+          </thead>
+        )}
+        <tbody>
+          {!hasSeparator && (
+            <tr>
+              {headerRow.map((cell, j) => (
+                <td key={j}>{formatInline(cell)}</td>
+              ))}
+            </tr>
+          )}
+          {dataRows.map((row, ri) => (
+            <tr key={ri}>
+              {row.map((cell, ci) => (
+                <td key={ci}>{formatInline(cell)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/** Format inline markdown: **bold**, `code` */
+function formatInline(text: string): (string | JSX.Element)[] {
+  const parts: (string | JSX.Element)[] = [];
+  const regex = /(\*\*(.+?)\*\*|`(.+?)`)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    if (match[2]) {
+      parts.push(<strong key={match.index}>{match[2]}</strong>);
+    } else if (match[3]) {
+      parts.push(<code key={match.index}>{match[3]}</code>);
+    }
+    lastIndex = regex.lastIndex;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  return parts.length > 0 ? parts : [text];
+}
+
 export default function JournalCard({ entry }: JournalCardProps) {
   const [expanded, setExpanded] = useState(false);
 
@@ -15,6 +168,7 @@ export default function JournalCard({ entry }: JournalCardProps) {
     date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
 
   const isSuccess = entry.buildResult?.status === 'success';
+  const isPlanning = entry.mode === 'planning';
 
   return (
     <div className={`journal-card mode-${entry.mode || 'research'}${expanded ? ' expanded' : ''}`}>
@@ -34,12 +188,28 @@ export default function JournalCard({ entry }: JournalCardProps) {
         </div>
       )}
 
+      {isPlanning && !entry.buildResult && (
+        <div className="build-indicator plan">
+          <span className="led"></span>
+          PLAN DESIGNED
+        </div>
+      )}
+
       <div className="card-body">
         <div className="card-body-inner">
           <div className="card-section">
             <div className="section-title"><span className="icon">{'\uD83E\uDDE0'}</span> Reasoning</div>
             <div className="reasoning-block">{entry.reasoning || ''}</div>
           </div>
+
+          {entry.planOutput && (
+            <div className="card-section">
+              <div className="section-title"><span className="icon">{'\uD83D\uDCCB'}</span> Plan Output</div>
+              <div className="plan-output-block">
+                <MarkdownContent text={entry.planOutput} />
+              </div>
+            </div>
+          )}
 
           {entry.filesModified && entry.filesModified.length > 0 && (
             <div className="card-section">
@@ -53,7 +223,7 @@ export default function JournalCard({ entry }: JournalCardProps) {
           )}
 
           <div className="card-section">
-            <div className="section-title"><span className="icon">{'\uD83D\uDCCB'}</span> Summary</div>
+            <div className="section-title"><span className="icon">{'\uD83D\uDCDD'}</span> Summary</div>
             <div className="summary-block">{entry.summary || ''}</div>
           </div>
 

--- a/docs/src/lib/types.ts
+++ b/docs/src/lib/types.ts
@@ -13,6 +13,8 @@ export interface JournalEntry {
   stats?: {
     tokensUsed?: number;
   };
+  /** Strategy-notes additions for planning cycles — the actual plan output */
+  planOutput?: string;
 }
 
 export interface Move {

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -34,6 +34,8 @@
   --yellow-bright: #ffd740;
   --blue-bright: #448aff;
   --purple-bright: #b388ff;
+  --cyan-bright: #00e5ff;
+  --cyan-glow: rgba(0, 229, 255, 0.15);
 
   --font-pixel: 'Press Start 2P', monospace;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
@@ -341,6 +343,7 @@ body::after {
 .journal-card.mode-research::before { border-color: var(--blue-bright); box-shadow: 0 0 8px rgba(68, 138, 255, 0.3); }
 .journal-card.mode-patch::before { border-color: var(--yellow-bright); box-shadow: 0 0 8px rgba(255, 215, 64, 0.3); }
 .journal-card.mode-feature::before { border-color: var(--purple-bright); box-shadow: 0 0 8px rgba(179, 136, 255, 0.3); }
+.journal-card.mode-planning::before { border-color: var(--cyan-bright); box-shadow: 0 0 8px rgba(0, 229, 255, 0.3); }
 
 /* Card Header */
 .card-header {
@@ -377,6 +380,7 @@ body::after {
 .mode-badge.research { background: rgba(68, 138, 255, 0.12); color: var(--blue-bright); border: 1px solid rgba(68, 138, 255, 0.25); }
 .mode-badge.patch { background: rgba(255, 215, 64, 0.12); color: var(--yellow-bright); border: 1px solid rgba(255, 215, 64, 0.25); }
 .mode-badge.feature { background: rgba(179, 136, 255, 0.12); color: var(--purple-bright); border: 1px solid rgba(179, 136, 255, 0.25); }
+.mode-badge.planning { background: rgba(0, 229, 255, 0.12); color: var(--cyan-bright); border: 1px solid rgba(0, 229, 255, 0.25); }
 
 .card-date {
   font-family: var(--font-mono);
@@ -444,6 +448,13 @@ body::after {
 .build-indicator.success .led { background: var(--green-bright); box-shadow: 0 0 6px var(--green-bright); }
 .build-indicator.failure .led { background: var(--red-bright); box-shadow: 0 0 6px var(--red-bright); }
 
+.build-indicator.plan {
+  background: var(--cyan-glow);
+  color: var(--cyan-bright);
+  border: 1px solid rgba(0, 229, 255, 0.2);
+}
+.build-indicator.plan .led { background: var(--cyan-bright); box-shadow: 0 0 6px var(--cyan-bright); }
+
 /* Card Body (expandable) */
 .card-body {
   max-height: 0;
@@ -495,6 +506,107 @@ body::after {
   background: rgba(0, 0, 0, 0.2);
   border-radius: var(--radius-md);
   border-left: 3px solid var(--text-muted);
+}
+
+/* Plan output block */
+.plan-output-block {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  max-height: 600px;
+  overflow-y: auto;
+  padding: 16px;
+  background: rgba(0, 229, 255, 0.03);
+  border: 1px solid rgba(0, 229, 255, 0.1);
+  border-radius: var(--radius-md);
+  border-left: 3px solid var(--cyan-bright);
+}
+
+.plan-output-block h4 {
+  color: var(--cyan-bright);
+  font-size: 15px;
+  font-weight: 700;
+  margin: 16px 0 8px;
+}
+
+.plan-output-block h4:first-child { margin-top: 0; }
+
+.plan-output-block h5 {
+  color: var(--cyan-bright);
+  font-size: 13px;
+  font-weight: 600;
+  margin: 12px 0 6px;
+}
+
+.plan-output-block h6 {
+  color: var(--text-accent);
+  font-size: 12px;
+  font-weight: 600;
+  margin: 10px 0 4px;
+}
+
+.plan-output-block p {
+  margin: 4px 0;
+}
+
+.plan-output-block ul {
+  list-style: disc;
+  padding-left: 20px;
+  margin: 6px 0;
+}
+
+.plan-output-block li {
+  margin: 2px 0;
+  font-size: 12px;
+}
+
+.plan-output-block hr {
+  border: none;
+  border-top: 1px solid rgba(0, 229, 255, 0.1);
+  margin: 12px 0;
+}
+
+.plan-output-block code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 1px 4px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 3px;
+  color: var(--cyan-bright);
+}
+
+.plan-output-block strong {
+  color: var(--text-primary);
+}
+
+.plan-table-wrapper {
+  overflow-x: auto;
+  margin: 8px 0;
+}
+
+.plan-output-block table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+  font-family: var(--font-mono);
+}
+
+.plan-output-block th,
+.plan-output-block td {
+  padding: 4px 8px;
+  border: 1px solid rgba(0, 229, 255, 0.12);
+  text-align: left;
+  white-space: nowrap;
+}
+
+.plan-output-block th {
+  background: rgba(0, 229, 255, 0.06);
+  color: var(--cyan-bright);
+  font-weight: 600;
+}
+
+.plan-output-block td {
+  color: var(--text-secondary);
 }
 
 /* Actions list */

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -24,6 +24,7 @@ import {
   getHeadSha,
   revertPokeemerald,
   getDiffStats,
+  getStrategyNotesDiff,
   getGitStatusText,
   getRecentGitLogText,
 } from "../git/committer.js";
@@ -579,6 +580,12 @@ export async function runCycle(): Promise<void> {
     fs.mkdirSync(ARTIFACTS_DIR, { recursive: true });
     fs.writeFileSync(cycleJsonPath, JSON.stringify({ cycle: String(cycleNumber).padStart(4, "0") }, null, 2) + "\n", "utf-8");
 
+    // For planning cycles, capture the strategy-notes additions as plan output
+    let planOutput: string | undefined;
+    if (plan.mode === "planning") {
+      planOutput = await getStrategyNotesDiff() || undefined;
+    }
+
     log.info("Phase 5: Writing journal entry...");
     const journalFile = writeJournalEntry({
       cycleNumber,
@@ -603,6 +610,7 @@ export async function runCycle(): Promise<void> {
       toolCallCount: implResult.toolCallCount + fixActions.length,
       issueActions: plan.issueActions.length > 0 ? plan.issueActions : undefined,
       helpRequests: plan.helpRequests.length > 0 ? plan.helpRequests : undefined,
+      planOutput,
     });
 
     // Apply agent-declared version bump / release stage before committing

--- a/src/git/committer.ts
+++ b/src/git/committer.ts
@@ -186,6 +186,26 @@ export async function getDiff(): Promise<string> {
   }
 }
 
+/**
+ * Get added lines from the memory/strategy-notes.md diff (staged + unstaged vs HEAD).
+ * Used to capture plan output for planning cycles.
+ */
+export async function getStrategyNotesDiff(): Promise<string> {
+  try {
+    const diff = await git.diff(["HEAD", "--", "memory/strategy-notes.md"]);
+    if (!diff) return "";
+    // Extract only added lines (skip diff headers)
+    return diff
+      .split("\n")
+      .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+      .map((line) => line.slice(1))
+      .join("\n")
+      .trim();
+  } catch {
+    return "";
+  }
+}
+
 export interface DiffStats {
   filesChanged: number;
   insertions: number;

--- a/src/journal/writer.ts
+++ b/src/journal/writer.ts
@@ -24,6 +24,8 @@ export interface JournalData {
   helpRequests?: HelpRequest[];
   validationWarnings?: string[];
   validationStatus?: string;
+  /** For planning cycles: the content added to strategy-notes.md (the plan output) */
+  planOutput?: string;
 }
 
 /** Write a journal entry for a completed cycle */
@@ -50,6 +52,9 @@ export function writeJournalEntry(data: JournalData): string {
 
   const issueSection = formatIssueSection(data.issueActions, data.helpRequests);
   const validationSection = formatValidationSection(data.validationWarnings, data.validationStatus);
+  const planOutputSection = data.planOutput
+    ? `\n## Plan Output\n\n${data.planOutput}\n`
+    : "";
 
   const content = `# Cycle ${paddedNumber}
 
@@ -72,7 +77,7 @@ ${buildSection}
 ## Summary
 
 ${data.cycleSummary || "No summary provided."}
-${validationSection}
+${planOutputSection}${validationSection}
 ## Reflection
 
 ${data.reflectionText || "No reflection generated."}


### PR DESCRIPTION
For planning cycles (mode="planning"), the docs website now displays the
actual strategic output — move tables, trainer specs, implementation
roadmaps — that was written to strategy-notes.md during the cycle.

Runner changes:
- Add getStrategyNotesDiff() to capture strategy-notes additions
- Add planOutput field to JournalData interface
- Write ## Plan Output section in journal for planning cycles
- Capture strategy-notes diff after implementation phase

Docs changes:
- Parse ## Plan Output section in build script with git-diff fallback
  for existing journals (extracts from commit history)
- Add lightweight markdown renderer (headers, tables, bullets, bold)
- Add "PLAN DESIGNED" status indicator for planning cycles
- Add cyan color scheme for planning mode (timeline dot, badge, indicator)
- Add scrollable plan output block with table styling

https://claude.ai/code/session_01DkcyZc993ZXz6E2u7x5ywK