### PR TITLE
Increase producer agent timeout from 10 to 15 minutes

### DIFF
--- a/src/cycle/team-planner.ts
+++ b/src/cycle/team-planner.ts
@@ -164,7 +164,7 @@ ${formatPlannerClosingInstructions()}`;
 
   const result = await runClaudeCode(prompt, {
     maxTurns: 50,
-    timeout: 10 * 60 * 1000,
+    timeout: 15 * 60 * 1000,
     model,
     jsonSchema: CYCLE_PLAN_SCHEMA,
   });


### PR DESCRIPTION
The producer agent timed out twice in the last cycle. Bumping from
10 min to 15 min to give it enough headroom for synthesis.

https://claude.ai/code/session_0133nXfyTLtqW5YTkHT8ZUBo