### PR TITLE
Add test framework and 60 unit tests for agent runner reliability

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "cycle": "tsx src/index.ts",
     "build:check": "tsc --noEmit",
     "build:docs": "cd docs && npm run build",
-    "debug:mcp": "tsx src/mcp/debug-ui.ts"
+    "debug:mcp": "tsx src/mcp/debug-ui.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -27,6 +29,7 @@
   "devDependencies": {
     "@types/node": "^22.12.0",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.2"
   }
 }

--- a/src/agent/output-parser.test.ts
+++ b/src/agent/output-parser.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect } from "vitest";
+import { parseClaudeOutput } from "./output-parser.js";
+
+/** Helper to build an NDJSON message line */
+function msg(
+  type: string,
+  content?: unknown[],
+  extra?: Record<string, unknown>,
+): string {
+  return JSON.stringify({ type, content, ...extra });
+}
+
+/** Helper to build a text content block */
+function textBlock(text: string) {
+  return { type: "text", text };
+}
+
+/** Helper to build a tool_use content block */
+function toolUse(name: string, input: Record<string, unknown> = {}) {
+  return { type: "tool_use", name, input };
+}
+
+/** Helper to build a tool_result content block */
+function toolResult(content: string) {
+  return { type: "tool_result", content };
+}
+
+describe("parseClaudeOutput", () => {
+  // --- Basic parsing ---
+
+  it("returns defaults for empty input", () => {
+    const result = parseClaudeOutput("");
+    expect(result.cycleSummary).toBe("");
+    expect(result.cycleChanges).toEqual([]);
+    expect(result.nextSteps).toBe("");
+    expect(result.issueOutcomes).toEqual([]);
+    expect(result.versionBump).toBeUndefined();
+    expect(result.releaseStage).toBeUndefined();
+    expect(result.actions).toEqual([]);
+    expect(result.filesModified).toEqual([]);
+    expect(result.buildResult).toBeNull();
+    expect(result.toolCallCount).toBe(0);
+    expect(result.tokenUsage.totalTokens).toBe(0);
+  });
+
+  it("returns defaults for whitespace-only input", () => {
+    const result = parseClaudeOutput("   \n  \n  ");
+    expect(result.actions).toEqual([]);
+    expect(result.toolCallCount).toBe(0);
+  });
+
+  it("parses NDJSON format (one JSON object per line)", () => {
+    const input = [
+      msg("assistant", [textBlock("hello world - this is a long enough message to be considered")]),
+      msg("assistant", [toolUse("Read", { file_path: "/tmp/test.ts" })]),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.toolCallCount).toBe(1);
+    expect(result.actions).toHaveLength(1);
+    expect(result.actions[0].tool).toBe("Read");
+  });
+
+  it("parses JSON array format", () => {
+    const messages = [
+      { type: "assistant", content: [toolUse("Read", { file_path: "/tmp/a.ts" })] },
+      { type: "assistant", content: [toolUse("Write", { file_path: "/tmp/b.ts" })] },
+    ];
+    const result = parseClaudeOutput(JSON.stringify(messages));
+    expect(result.toolCallCount).toBe(2);
+  });
+
+  it("skips non-JSON lines in NDJSON input", () => {
+    const input = [
+      "this is not json",
+      msg("assistant", [toolUse("Read", { file_path: "/tmp/a.ts" })]),
+      "another non-json line",
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.toolCallCount).toBe(1);
+  });
+
+  // --- CYCLE_COMPLETE marker ---
+
+  it("extracts CYCLE_COMPLETE marker with all fields", () => {
+    const marker = JSON.stringify({
+      summary: "Did great stuff",
+      changes: ["Added feature X", "Fixed bug Y"],
+      next_steps: "Continue with Z",
+      issue_outcomes: [{ number: 42, status: "complete" }],
+      version_bump: "minor",
+      release_stage: "Beta",
+    });
+    const input = msg("assistant", [
+      textBlock(`Some text\n<!-- CYCLE_COMPLETE: ${marker} -->\nMore text`),
+    ]);
+    const result = parseClaudeOutput(input);
+    expect(result.cycleSummary).toBe("Did great stuff");
+    expect(result.cycleChanges).toEqual(["Added feature X", "Fixed bug Y"]);
+    expect(result.nextSteps).toBe("Continue with Z");
+    expect(result.issueOutcomes).toEqual([{ number: 42, status: "complete" }]);
+    expect(result.versionBump).toBe("minor");
+    expect(result.releaseStage).toBe("Beta");
+  });
+
+  it("handles CYCLE_COMPLETE with partial fields", () => {
+    const marker = JSON.stringify({ summary: "Partial work" });
+    const input = msg("assistant", [
+      textBlock(`<!-- CYCLE_COMPLETE: ${marker} -->`),
+    ]);
+    const result = parseClaudeOutput(input);
+    expect(result.cycleSummary).toBe("Partial work");
+    expect(result.cycleChanges).toEqual([]);
+    expect(result.nextSteps).toBe("");
+    expect(result.issueOutcomes).toEqual([]);
+    expect(result.versionBump).toBeUndefined();
+    expect(result.releaseStage).toBeUndefined();
+  });
+
+  it("handles CYCLE_COMPLETE with malformed JSON gracefully", () => {
+    const input = msg("assistant", [
+      textBlock("<!-- CYCLE_COMPLETE: {this is not valid json} -->"),
+    ]);
+    const result = parseClaudeOutput(input);
+    // Should not crash, fields stay default
+    expect(result.cycleSummary).toBe("");
+    expect(result.cycleChanges).toEqual([]);
+  });
+
+  // --- issue_outcomes ---
+
+  it("parses complete and partial issue outcomes", () => {
+    const marker = JSON.stringify({
+      summary: "s",
+      issue_outcomes: [
+        { number: 1, status: "complete" },
+        { number: 2, status: "partial", decision: "defer", reason: "needs more work" },
+      ],
+    });
+    const input = msg("assistant", [textBlock(`<!-- CYCLE_COMPLETE: ${marker} -->`)]);
+    const result = parseClaudeOutput(input);
+    expect(result.issueOutcomes).toHaveLength(2);
+    expect(result.issueOutcomes[0]).toEqual({ number: 1, status: "complete" });
+    expect(result.issueOutcomes[1]).toEqual({
+      number: 2,
+      status: "partial",
+      decision: "defer",
+      reason: "needs more work",
+    });
+  });
+
+  it("filters out invalid issue outcomes", () => {
+    const marker = JSON.stringify({
+      summary: "s",
+      issue_outcomes: [
+        { number: 1, status: "complete" },
+        { status: "complete" }, // missing number
+        { number: 3, status: "invalid_status" }, // wrong status
+        null,
+        "not an object",
+      ],
+    });
+    const input = msg("assistant", [textBlock(`<!-- CYCLE_COMPLETE: ${marker} -->`)]);
+    const result = parseClaudeOutput(input);
+    expect(result.issueOutcomes).toHaveLength(1);
+    expect(result.issueOutcomes[0].number).toBe(1);
+  });
+
+  it("parses item_outcomes for multi-item issues", () => {
+    const marker = JSON.stringify({
+      summary: "s",
+      issue_outcomes: [
+        {
+          number: 42,
+          status: "partial",
+          decision: "defer",
+          reason: "2 of 4 done",
+          item_outcomes: [
+            { label: "Bug A", status: "complete" },
+            { label: "Bug B", status: "not-started", decision: "defer", reason: "later" },
+          ],
+        },
+      ],
+    });
+    const input = msg("assistant", [textBlock(`<!-- CYCLE_COMPLETE: ${marker} -->`)]);
+    const result = parseClaudeOutput(input);
+    expect(result.issueOutcomes).toHaveLength(1);
+    expect(result.issueOutcomes[0].itemOutcomes).toHaveLength(2);
+    expect(result.issueOutcomes[0].itemOutcomes![0].label).toBe("Bug A");
+    expect(result.issueOutcomes[0].itemOutcomes![1].status).toBe("not-started");
+  });
+
+  // --- version_bump and release_stage ---
+
+  it("extracts version_bump 'major'", () => {
+    const marker = JSON.stringify({ summary: "s", version_bump: "major" });
+    const input = msg("assistant", [textBlock(`<!-- CYCLE_COMPLETE: ${marker} -->`)]);
+    expect(parseClaudeOutput(input).versionBump).toBe("major");
+  });
+
+  it("ignores invalid version_bump values", () => {
+    const marker = JSON.stringify({ summary: "s", version_bump: "patch" });
+    const input = msg("assistant", [textBlock(`<!-- CYCLE_COMPLETE: ${marker} -->`)]);
+    expect(parseClaudeOutput(input).versionBump).toBeUndefined();
+  });
+
+  it("ignores empty/whitespace-only release_stage", () => {
+    const marker1 = JSON.stringify({ summary: "s", release_stage: "" });
+    const input1 = msg("assistant", [textBlock(`<!-- CYCLE_COMPLETE: ${marker1} -->`)]);
+    expect(parseClaudeOutput(input1).releaseStage).toBeUndefined();
+
+    const marker2 = JSON.stringify({ summary: "s", release_stage: "   " });
+    const input2 = msg("assistant", [textBlock(`<!-- CYCLE_COMPLETE: ${marker2} -->`)]);
+    expect(parseClaudeOutput(input2).releaseStage).toBeUndefined();
+  });
+
+  // --- Tool call tracking ---
+
+  it("counts tool calls correctly", () => {
+    const input = [
+      msg("assistant", [
+        toolUse("Read", { file_path: "/a" }),
+        toolUse("Write", { file_path: "/b" }),
+      ]),
+      msg("assistant", [toolUse("Bash", { command: "ls" })]),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.toolCallCount).toBe(3);
+  });
+
+  it("tracks file modifications from Write/Edit/MultiEdit", () => {
+    const input = [
+      msg("assistant", [toolUse("Write", { file_path: "/tmp/a.ts" })]),
+      msg("assistant", [toolUse("Edit", { file_path: "/tmp/b.ts" })]),
+      msg("assistant", [toolUse("MultiEdit", { file_path: "/tmp/c.ts" })]),
+      msg("assistant", [toolUse("Read", { file_path: "/tmp/d.ts" })]),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.filesModified).toContain("/tmp/a.ts");
+    expect(result.filesModified).toContain("/tmp/b.ts");
+    expect(result.filesModified).toContain("/tmp/c.ts");
+    expect(result.filesModified).not.toContain("/tmp/d.ts");
+  });
+
+  it("tracks file modifications from fetch_pokemon_sprites", () => {
+    const input = msg("assistant", [
+      toolUse("fetch_pokemon_sprites", { name: "Lucario" }),
+    ]);
+    const result = parseClaudeOutput(input);
+    expect(result.filesModified).toHaveLength(7);
+    expect(result.filesModified).toContain("pokeemerald/graphics/pokemon/lucario/front.png");
+    expect(result.filesModified).toContain("pokeemerald/graphics/pokemon/lucario/normal.pal");
+    expect(result.filesModified).toContain("pokeemerald/graphics/pokemon/lucario/shiny.pal");
+  });
+
+  it("deduplicates file modifications", () => {
+    const input = [
+      msg("assistant", [toolUse("Write", { file_path: "/tmp/a.ts" })]),
+      msg("assistant", [toolUse("Edit", { file_path: "/tmp/a.ts" })]),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.filesModified.filter((f) => f === "/tmp/a.ts")).toHaveLength(1);
+  });
+
+  // --- Build result detection ---
+
+  it("detects successful build from make command", () => {
+    const input = [
+      msg("assistant", [toolUse("Bash", { command: "cd pokeemerald && make" })]),
+      msg("assistant", [toolResult("make: Nothing to be done for 'all'.")]),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.buildResult).not.toBeNull();
+    expect(result.buildResult!.success).toBe(true);
+  });
+
+  it("detects failed build with errors", () => {
+    const input = [
+      msg("assistant", [toolUse("Bash", { command: "make" })]),
+      msg("assistant", [
+        toolResult(
+          "make[1]: Entering directory\nsrc/main.c:10:5: error: undeclared identifier\nmake[1]: *** [target] Error 2",
+        ),
+      ]),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.buildResult).not.toBeNull();
+    expect(result.buildResult!.success).toBe(false);
+    expect(result.buildResult!.errors.length).toBeGreaterThan(0);
+  });
+
+  it("does not detect build for make_tools commands", () => {
+    const input = msg("assistant", [
+      toolUse("Bash", { command: "make make_tools" }),
+    ]);
+    // make_tools is excluded from build detection
+    // The command contains "make_tools" so the !cmd.includes("make_tools") check filters it
+    // But it also contains "make" — let's verify the implementation's behavior
+    const result = parseClaudeOutput(input);
+    expect(result.buildResult).toBeNull();
+  });
+
+  // --- Token usage ---
+
+  it("accumulates token usage from message usage fields", () => {
+    const input = [
+      msg("assistant", [textBlock("hello")], {
+        usage: { input_tokens: 100, output_tokens: 50 },
+      }),
+      msg("assistant", [textBlock("world")], {
+        usage: { input_tokens: 200, output_tokens: 75 },
+      }),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.tokenUsage.inputTokens).toBe(300);
+    expect(result.tokenUsage.outputTokens).toBe(125);
+    expect(result.tokenUsage.totalTokens).toBe(425);
+  });
+
+  it("uses cumulative result usage when no per-message usage exists", () => {
+    const input = msg("result", [textBlock("done")], {
+      result: "final result",
+      usage: { input_tokens: 500, output_tokens: 200 },
+    });
+    const result = parseClaudeOutput(input);
+    expect(result.tokenUsage.inputTokens).toBe(500);
+    expect(result.tokenUsage.outputTokens).toBe(200);
+  });
+
+  // --- Narrative text ---
+
+  it("collects pre-marker text as narrative", () => {
+    const longText =
+      "This is a substantial piece of narrative text that describes what the agent did during this cycle in great detail.";
+    const marker = JSON.stringify({ summary: "Done" });
+    const input = [
+      msg("assistant", [textBlock(longText)]),
+      msg("assistant", [textBlock(`<!-- CYCLE_COMPLETE: ${marker} -->`)]),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.narrativeText).toContain("substantial piece of narrative");
+  });
+
+  it("uses post-marker text as fallback summary when summary is empty", () => {
+    const marker = JSON.stringify({ summary: "" });
+    const longText =
+      "This is a long post-marker text that the agent wrote after the CYCLE_COMPLETE marker as an Oak-voiced reflection.";
+    const input = [
+      msg("assistant", [textBlock(`<!-- CYCLE_COMPLETE: ${marker} -->`)]),
+      msg("assistant", [textBlock(longText)]),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    expect(result.cycleSummary).toContain("post-marker text");
+  });
+
+  // --- Result text ---
+
+  it("captures result text from result-type messages", () => {
+    const input = msg("result", [], { result: "the final answer" });
+    const result = parseClaudeOutput(input);
+    expect(result.resultText).toBe("the final answer");
+  });
+
+  it("filters out '(no content)' from result text", () => {
+    const input = msg("result", [], { result: "(no content)" });
+    const result = parseClaudeOutput(input);
+    expect(result.resultText).toBe("");
+  });
+
+  // --- StructuredOutput merging ---
+
+  it("merges StructuredOutput tool inputs into resultText", () => {
+    const input = [
+      msg("assistant", [toolUse("StructuredOutput", { mode: "research", objective: "test" })]),
+      msg("assistant", [toolUse("StructuredOutput", { issueActions: [] })]),
+    ].join("\n");
+    const result = parseClaudeOutput(input);
+    const parsed = JSON.parse(result.resultText);
+    expect(parsed.mode).toBe("research");
+    expect(parsed.objective).toBe("test");
+    expect(parsed.issueActions).toEqual([]);
+  });
+
+  // --- Stream-json nested message format ---
+
+  it("handles stream-json format with nested msg.message content", () => {
+    const input = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [textBlock("nested content that is long enough to be considered substantial text for narrative")],
+        usage: { input_tokens: 42, output_tokens: 10 },
+      },
+    });
+    const result = parseClaudeOutput(input);
+    expect(result.tokenUsage.inputTokens).toBe(42);
+    expect(result.tokenUsage.outputTokens).toBe(10);
+  });
+});

--- a/src/github/issues.test.ts
+++ b/src/github/issues.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Tests for pure/near-pure functions in the issues module.
+ * We mock fs and the GitHub client to avoid I/O.
+ */
+
+// The BACKLOG_LINE_RE regex is not exported, so we test it indirectly through
+// parseBacklogEntries (which reads from fs). We also test formatIssuesForPrompt.
+
+const mockFs = {
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.resetAllMocks();
+});
+
+async function importIssuesModule() {
+  vi.doMock("fs", () => ({ default: mockFs }));
+  vi.doMock("../utils/logger.js", () => ({
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  }));
+  vi.doMock("../utils/paths.js", () => ({
+    MEMORY_DIR: "/tmp/test-memory",
+  }));
+  // Mock the GitHub client module to avoid Octokit initialization
+  vi.doMock("./client.js", () => ({
+    fetchOpenIssues: vi.fn().mockResolvedValue([]),
+    commentOnIssue: vi.fn().mockResolvedValue(undefined),
+    addLabelsToIssue: vi.fn().mockResolvedValue(undefined),
+    closeIssue: vi.fn().mockResolvedValue(undefined),
+    createIssue: vi.fn().mockResolvedValue(undefined),
+    getGitHubClient: vi.fn().mockReturnValue(null),
+    AGENT_LABELS: {
+      reviewed: "agent-reviewed",
+      accepted: "agent-accepted",
+      deferred: "agent-deferred",
+      rejected: "agent-rejected",
+      needsInfo: "agent-needs-info",
+      helpRequest: "agent-help-request",
+    },
+    COMMUNITY_LABELS: ["suggestion", "trainer-tip", "bug-report", "idea"],
+  }));
+  return import("./issues.js");
+}
+
+describe("parseBacklogEntries", () => {
+  it("returns empty array when backlog file does not exist", async () => {
+    mockFs.existsSync.mockReturnValue(false);
+    const { parseBacklogEntries } = await importIssuesModule();
+    expect(parseBacklogEntries()).toEqual([]);
+  });
+
+  it("parses basic backlog entries", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      "- #42: Add Riolu encounters (deferred: cycle 10)\n- #7: Fix trainer levels (deferred: cycle 5)\n",
+    );
+    const { parseBacklogEntries } = await importIssuesModule();
+    const entries = parseBacklogEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toEqual({
+      issueNumber: 42,
+      title: "Add Riolu encounters",
+      deferredAtCycle: 10,
+      pendingItems: undefined,
+    });
+    expect(entries[1].issueNumber).toBe(7);
+    expect(entries[1].deferredAtCycle).toBe(5);
+  });
+
+  it("parses entries with pending items", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      "- #42: Multi-item issue (deferred: cycle 10) | pending: Bug A; Feature B\n",
+    );
+    const { parseBacklogEntries } = await importIssuesModule();
+    const entries = parseBacklogEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].pendingItems).toEqual(["Bug A", "Feature B"]);
+  });
+
+  it("handles legacy entries without cycle number", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue("- #99: Legacy issue\n");
+    const { parseBacklogEntries } = await importIssuesModule();
+    const entries = parseBacklogEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].deferredAtCycle).toBe(0);
+  });
+
+  it("skips non-matching lines", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      "# Backlog\n\nSome random text\n- #42: Valid entry (deferred: cycle 5)\n\n",
+    );
+    const { parseBacklogEntries } = await importIssuesModule();
+    const entries = parseBacklogEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].issueNumber).toBe(42);
+  });
+});
+
+describe("getStaleBacklogIssues", () => {
+  it("returns entries deferred for >= threshold cycles", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(
+      [
+        "- #1: Old issue (deferred: cycle 5)",
+        "- #2: Recent issue (deferred: cycle 18)",
+        "- #3: Edge case (deferred: cycle 10)",
+      ].join("\n"),
+    );
+    const { getStaleBacklogIssues } = await importIssuesModule();
+    const stale = getStaleBacklogIssues(20, 10);
+    // #1: 20-5=15 >= 10 ✓, #2: 20-18=2 < 10 ✗, #3: 20-10=10 >= 10 ✓
+    expect(stale).toHaveLength(2);
+    expect(stale.map((e) => e.issueNumber)).toEqual([1, 3]);
+  });
+
+  it("returns empty array when no entries are stale", async () => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue("- #1: Fresh issue (deferred: cycle 18)\n");
+    const { getStaleBacklogIssues } = await importIssuesModule();
+    expect(getStaleBacklogIssues(20, 10)).toEqual([]);
+  });
+});
+
+describe("formatIssuesForPrompt", () => {
+  it("returns empty string for no issues", async () => {
+    const { formatIssuesForPrompt } = await importIssuesModule();
+    expect(formatIssuesForPrompt([])).toBe("");
+  });
+
+  it("formats issues with all fields", async () => {
+    const { formatIssuesForPrompt } = await importIssuesModule();
+    const result = formatIssuesForPrompt([
+      {
+        number: 42,
+        title: "Add Riolu",
+        body: "Please add Riolu to the game!",
+        labels: ["suggestion"],
+        state: "open" as const,
+        author: "trainer123",
+        createdAt: "2025-01-15",
+        upvotes: 5,
+      },
+    ]);
+    expect(result).toContain("Issue #42: Add Riolu");
+    expect(result).toContain("[suggestion]");
+    expect(result).toContain("trainer123");
+    expect(result).toContain("Upvotes**: 5");
+    expect(result).toContain("Please add Riolu");
+    expect(result).toContain("1 new community issue");
+  });
+
+  it("truncates long issue bodies", async () => {
+    const { formatIssuesForPrompt } = await importIssuesModule();
+    const longBody = "x".repeat(3000);
+    const result = formatIssuesForPrompt([
+      {
+        number: 1,
+        title: "Test",
+        body: longBody,
+        labels: [],
+        state: "open" as const,
+        author: "user",
+        createdAt: "2025-01-01",
+        upvotes: 0,
+      },
+    ]);
+    expect(result).toContain("...(truncated)");
+    // Body is truncated to 2000 chars, so the full 3000-char body should not appear
+    expect(result).not.toContain(longBody);
+  });
+
+  it("hides upvotes when zero", async () => {
+    const { formatIssuesForPrompt } = await importIssuesModule();
+    const result = formatIssuesForPrompt([
+      {
+        number: 1,
+        title: "Test",
+        body: "body",
+        labels: [],
+        state: "open" as const,
+        author: "user",
+        createdAt: "2025-01-01",
+        upvotes: 0,
+      },
+    ]);
+    expect(result).not.toContain("Upvotes");
+  });
+});

--- a/src/reflection/validator.test.ts
+++ b/src/reflection/validator.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { validateCycle, type DiffStats } from "./validator.js";
+import type { ClaudeCodeResult } from "../agent/output-parser.js";
+
+/** Build a minimal ClaudeCodeResult with overrides */
+function makeResult(overrides: Partial<ClaudeCodeResult> = {}): ClaudeCodeResult {
+  return {
+    actions: [],
+    filesModified: [],
+    buildResult: null,
+    cycleSummary: "",
+    cycleChanges: [],
+    nextSteps: "",
+    issueOutcomes: [],
+    tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    toolCallCount: 0,
+    resultText: "",
+    narrativeText: "",
+    ...overrides,
+  };
+}
+
+function makeDiff(overrides: Partial<DiffStats> = {}): DiffStats {
+  return {
+    filesChanged: 0,
+    insertions: 0,
+    deletions: 0,
+    summary: "",
+    ...overrides,
+  };
+}
+
+describe("validateCycle", () => {
+  it("returns verified when feature mode has pokeemerald changes", () => {
+    const result = validateCycle({
+      mode: "feature",
+      objective: "Add new encounters",
+      implResult: makeResult({
+        filesModified: ["pokeemerald/src/data/wild_encounters.json"],
+        actions: [
+          { tool: "Edit", input: { file_path: "pokeemerald/src/data/wild_encounters.json" }, result: "", timestamp: "" },
+        ],
+      }),
+      diffStats: makeDiff({ filesChanged: 1, insertions: 10 }),
+    });
+    expect(result.status).toBe("verified");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("returns unsubstantiated when feature mode has 0 diff but detailed summary", () => {
+    const result = validateCycle({
+      mode: "feature",
+      objective: "Redesign encounters",
+      implResult: makeResult({
+        cycleSummary: "I completely redesigned all wild encounters across every route in the game.",
+        actions: [{ tool: "Read", input: {}, result: "", timestamp: "" }],
+      }),
+      diffStats: makeDiff({ filesChanged: 0 }),
+    });
+    expect(result.status).toBe("unsubstantiated");
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("returns incomplete when feature mode has changes but no write actions", () => {
+    const result = validateCycle({
+      mode: "patch",
+      objective: "Fix trainer levels",
+      implResult: makeResult({
+        actions: [
+          { tool: "Read", input: {}, result: "", timestamp: "" },
+          { tool: "Bash", input: { command: "ls" }, result: "", timestamp: "" },
+        ],
+      }),
+      diffStats: makeDiff({ filesChanged: 1, insertions: 5 }),
+    });
+    expect(result.status).toBe("incomplete");
+    expect(result.warnings.some((w) => w.includes("write/edit operations"))).toBe(true);
+  });
+
+  it("returns verified for research mode regardless of diff", () => {
+    const result = validateCycle({
+      mode: "research",
+      objective: "Study battle system",
+      implResult: makeResult(),
+      diffStats: makeDiff({ filesChanged: 0 }),
+    });
+    expect(result.status).toBe("verified");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("returns verified for planning mode regardless of diff", () => {
+    const result = validateCycle({
+      mode: "planning",
+      objective: "Plan new features",
+      implResult: makeResult(),
+      diffStats: makeDiff({ filesChanged: 0 }),
+    });
+    expect(result.status).toBe("verified");
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it("warns when feature mode modifies only non-pokeemerald files", () => {
+    const result = validateCycle({
+      mode: "feature",
+      objective: "Add encounters",
+      implResult: makeResult({
+        filesModified: ["memory/strategy-notes.md"],
+        actions: [
+          { tool: "Write", input: { file_path: "memory/strategy-notes.md" }, result: "", timestamp: "" },
+        ],
+      }),
+      diffStats: makeDiff({ filesChanged: 0 }),
+    });
+    expect(result.warnings.some((w) => w.includes("no pokeemerald/ files"))).toBe(true);
+  });
+
+  it("handles absolute paths when checking for pokeemerald files", () => {
+    const result = validateCycle({
+      mode: "patch",
+      objective: "Fix bug",
+      implResult: makeResult({
+        filesModified: ["/home/user/agentoak/pokeemerald/src/main.c"],
+        actions: [
+          { tool: "Edit", input: { file_path: "/home/user/agentoak/pokeemerald/src/main.c" }, result: "", timestamp: "" },
+        ],
+      }),
+      diffStats: makeDiff({ filesChanged: 1, insertions: 2 }),
+    });
+    // This should work as long as PROJECT_ROOT resolves and the relative path starts with pokeemerald/
+    // The actual behavior depends on PROJECT_ROOT at test time
+    // At minimum, no crash
+    expect(["verified", "incomplete"]).toContain(result.status);
+  });
+
+  it("detects repair mode as expecting code changes", () => {
+    const result = validateCycle({
+      mode: "repair",
+      objective: "Fix build",
+      implResult: makeResult(),
+      diffStats: makeDiff({ filesChanged: 0 }),
+    });
+    // repair mode expects changes but got none
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it("detects refactor mode as expecting code changes", () => {
+    const result = validateCycle({
+      mode: "refactor",
+      objective: "Clean up code",
+      implResult: makeResult(),
+      diffStats: makeDiff({ filesChanged: 0 }),
+    });
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+});

--- a/src/repo/version.test.ts
+++ b/src/repo/version.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { formatVersion, type GameVersion } from "./version.js";
+
+/** Build a minimal GameVersion */
+function makeVersion(overrides: Partial<GameVersion> = {}): GameVersion {
+  return {
+    major: 0,
+    minor: 0,
+    patch: 0,
+    build: 0,
+    cycle: 0,
+    builtAt: "",
+    ...overrides,
+  };
+}
+
+describe("formatVersion", () => {
+  it("formats a basic version", () => {
+    expect(formatVersion(makeVersion({ major: 0, minor: 3, cycle: 42, build: 7 }))).toBe(
+      "v0.3.42+build.7",
+    );
+  });
+
+  it("formats initial version", () => {
+    expect(formatVersion(makeVersion())).toBe("v0.0.0+build.0");
+  });
+
+  it("formats a major release", () => {
+    expect(formatVersion(makeVersion({ major: 1, minor: 0, cycle: 100, build: 50 }))).toBe(
+      "v1.0.100+build.50",
+    );
+  });
+
+  it("uses cycle number as the third segment, not patch", () => {
+    // The format is v{major}.{minor}.{cycle}+build.{build}
+    const v = makeVersion({ major: 2, minor: 5, patch: 99, cycle: 42, build: 10 });
+    expect(formatVersion(v)).toBe("v2.5.42+build.10");
+  });
+});
+
+// For the I/O-dependent functions (loadVersion, recordSuccessfulBuild, applyVersionBump,
+// setReleaseStage), we test them using fs mocking. We dynamically import the module
+// after mocking to ensure the mocks are in place.
+
+describe("version I/O functions", () => {
+  const mockFs = {
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+  });
+
+  // Using vi.doMock for dynamic ESM mocking
+  async function importVersionModule() {
+    vi.doMock("fs", () => ({ default: mockFs }));
+    // Also mock the logger to avoid winston initialization issues
+    vi.doMock("../utils/logger.js", () => ({
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    }));
+    const mod = await import("./version.js");
+    return mod;
+  }
+
+  it("loadVersion returns initial version when file does not exist", async () => {
+    mockFs.readFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const { loadVersion } = await importVersionModule();
+    const v = loadVersion();
+    expect(v.major).toBe(0);
+    expect(v.minor).toBe(0);
+    expect(v.build).toBe(0);
+  });
+
+  it("loadVersion reads and parses existing version file", async () => {
+    const stored = { major: 1, minor: 2, patch: 5, build: 10, cycle: 5, builtAt: "2025-01-01" };
+    mockFs.readFileSync.mockReturnValue(JSON.stringify(stored));
+    const { loadVersion } = await importVersionModule();
+    const v = loadVersion();
+    expect(v.major).toBe(1);
+    expect(v.minor).toBe(2);
+    expect(v.build).toBe(10);
+  });
+
+  it("recordSuccessfulBuild increments build and sets cycle", async () => {
+    const stored = { major: 0, minor: 1, patch: 3, build: 5, cycle: 3, builtAt: "" };
+    mockFs.readFileSync.mockReturnValue(JSON.stringify(stored));
+    const { recordSuccessfulBuild } = await importVersionModule();
+    const v = recordSuccessfulBuild(7);
+    expect(v.build).toBe(6);
+    expect(v.cycle).toBe(7);
+    expect(v.patch).toBe(7);
+    expect(mockFs.writeFileSync).toHaveBeenCalledOnce();
+  });
+
+  it("applyVersionBump 'major' increments major and resets minor", async () => {
+    const stored = { major: 0, minor: 3, patch: 10, build: 15, cycle: 10, builtAt: "" };
+    mockFs.readFileSync.mockReturnValue(JSON.stringify(stored));
+    const { applyVersionBump } = await importVersionModule();
+    const v = applyVersionBump("major");
+    expect(v.major).toBe(1);
+    expect(v.minor).toBe(0);
+  });
+
+  it("applyVersionBump 'minor' increments minor only", async () => {
+    const stored = { major: 1, minor: 3, patch: 10, build: 15, cycle: 10, builtAt: "" };
+    mockFs.readFileSync.mockReturnValue(JSON.stringify(stored));
+    const { applyVersionBump } = await importVersionModule();
+    const v = applyVersionBump("minor");
+    expect(v.major).toBe(1);
+    expect(v.minor).toBe(4);
+  });
+
+  it("applyVersionBump sets release stage when provided", async () => {
+    const stored = { major: 0, minor: 1, patch: 5, build: 8, cycle: 5, builtAt: "" };
+    mockFs.readFileSync.mockReturnValue(JSON.stringify(stored));
+    const { applyVersionBump } = await importVersionModule();
+    const v = applyVersionBump("minor", "Beta");
+    expect(v.releaseStage).toBe("Beta");
+  });
+
+  it("setReleaseStage sets label without changing numbers", async () => {
+    const stored = { major: 1, minor: 2, patch: 5, build: 10, cycle: 5, builtAt: "" };
+    mockFs.readFileSync.mockReturnValue(JSON.stringify(stored));
+    const { setReleaseStage } = await importVersionModule();
+    const v = setReleaseStage("Demo");
+    expect(v.releaseStage).toBe("Demo");
+    expect(v.major).toBe(1);
+    expect(v.minor).toBe(2);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Set up Vitest with ESM support and add comprehensive tests for the 4
highest-value pure-logic modules:

- output-parser: CYCLE_COMPLETE extraction, NDJSON/JSON parsing, tool
  call tracking, file modification detection, token usage, narratives
- validator: claim vs diff cross-checking for all cycle modes
- version: formatting, bumping (major/minor), release stage management
- issues: backlog parsing, stale detection, prompt formatting

All 60 tests pass. No integration tests (no CLI/git/make deps).

https://claude.ai/code/session_01LH58mzaw5Fo4ZXuAhm2jCy