### PR TITLE
Generalize MCP debug UI to support multiple servers (pokedex + porymap)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build:check": "tsc --noEmit",
     "build:docs": "cd docs && npm run build",
     "debug:mcp": "tsx src/mcp/debug-ui.ts",
+    "debug:mcp:porymap": "tsx src/mcp/debug-ui.ts porymap",
+    "debug:mcp:all": "tsx src/mcp/debug-ui.ts all",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/src/mcp/debug-ui.html
+++ b/src/mcp/debug-ui.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>MCP Debug UI — Pokédex Server</title>
+<title>MCP Debug UI</title>
 <style>
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -59,6 +59,49 @@
     color: var(--text-dim);
     margin-top: 4px;
   }
+
+  /* Server tabs */
+  .server-tabs {
+    display: flex;
+    gap: 4px;
+    padding: 8px 8px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .server-tab {
+    flex: 1;
+    padding: 8px 12px;
+    border-radius: var(--radius) var(--radius) 0 0;
+    border: 1px solid transparent;
+    border-bottom: none;
+    background: transparent;
+    color: var(--text-dim);
+    font-family: var(--font);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+    text-align: center;
+  }
+  .server-tab:hover {
+    background: var(--bg-card);
+    color: var(--text);
+  }
+  .server-tab.active {
+    background: var(--bg);
+    color: var(--accent);
+    border-color: var(--border);
+  }
+  .server-tab .tab-desc {
+    display: block;
+    font-size: 10px;
+    font-weight: 400;
+    color: var(--text-dim);
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   .tool-list {
     flex: 1;
     overflow-y: auto;
@@ -169,7 +212,8 @@
     line-height: 1.3;
   }
   .field input[type="text"],
-  .field input[type="number"] {
+  .field input[type="number"],
+  .field select {
     background: var(--bg-input);
     border: 1px solid var(--border);
     border-radius: 6px;
@@ -180,8 +224,9 @@
     outline: none;
     transition: border-color 0.15s;
   }
-  .field input:focus { border-color: var(--accent); }
+  .field input:focus, .field select:focus { border-color: var(--accent); }
   .field input::placeholder { color: var(--text-dim); opacity: 0.5; }
+  .field select option { background: var(--bg-input); color: var(--text); }
 
   .field-checkbox {
     flex-direction: row;
@@ -257,7 +302,7 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: 8px;
-	  flex-shrink: 0;
+    flex-shrink: 0;
   }
   .output-header h3 {
     font-size: 11px;
@@ -333,8 +378,9 @@
 <aside class="sidebar">
   <div class="sidebar-header">
     <h1>MCP Debug UI</h1>
-    <p>Pokédex Server — Tool Explorer</p>
+    <p id="sidebarSubtitle">Tool Explorer</p>
   </div>
+  <div class="server-tabs" id="serverTabs" style="display:none"></div>
   <div class="tool-list" id="toolList">
     <div class="empty-state" style="padding: 40px 0">
       <div class="spinner"></div>
@@ -358,21 +404,75 @@
 
 <script>
 const API = '';
+let servers = [];
+let currentServer = null;
 let tools = [];
 let selectedTool = null;
 let isLoading = false;
 let lastResult = null;
 let lastDuration = null;
 
-async function fetchTools() {
+async function init() {
   try {
-    const res = await fetch(`${API}/api/tools`);
-    tools = await res.json();
-    renderToolList();
-    if (tools.length > 0) selectTool(tools[0].name);
-  } catch (err) {
+    const res = await fetch(`${API}/api/servers`);
+    servers = await res.json();
+  } catch {
     document.getElementById('toolList').innerHTML =
       `<div class="empty-state" style="padding:40px 16px"><p style="font-size:12px;color:var(--accent)">Failed to connect to MCP server.<br>Is it running?</p></div>`;
+    return;
+  }
+
+  if (servers.length === 0) return;
+
+  currentServer = servers[0].key;
+
+  if (servers.length > 1) {
+    renderServerTabs();
+    document.getElementById('serverTabs').style.display = 'flex';
+    document.getElementById('sidebarSubtitle').textContent = 'Multi-Server Tool Explorer';
+  } else {
+    document.getElementById('sidebarSubtitle').textContent =
+      servers[0].label + ' \u2014 Tool Explorer';
+  }
+
+  document.title = servers.length > 1
+    ? 'MCP Debug UI'
+    : `MCP Debug UI \u2014 ${servers[0].label}`;
+
+  fetchTools();
+}
+
+function renderServerTabs() {
+  const el = document.getElementById('serverTabs');
+  el.innerHTML = servers.map(s => `
+    <button class="server-tab ${currentServer === s.key ? 'active' : ''}"
+            onclick="switchServer('${s.key}')">
+      ${escapeHtml(s.label)}
+      <span class="tab-desc">${escapeHtml(s.description)}</span>
+    </button>
+  `).join('');
+}
+
+function switchServer(key) {
+  if (currentServer === key) return;
+  currentServer = key;
+  selectedTool = null;
+  lastResult = null;
+  lastDuration = null;
+  renderServerTabs();
+  fetchTools();
+  renderMain();
+}
+
+async function fetchTools() {
+  try {
+    const res = await fetch(`${API}/api/tools?server=${currentServer}`);
+    tools = await res.json();
+    renderToolList();
+    if (tools.length > 0 && !selectedTool) selectTool(tools[0].name);
+  } catch (err) {
+    document.getElementById('toolList').innerHTML =
+      `<div class="empty-state" style="padding:40px 16px"><p style="font-size:12px;color:var(--accent)">Failed to load tools.<br>${escapeHtml(String(err))}</p></div>`;
   }
 }
 
@@ -399,6 +499,13 @@ function renderMain() {
   const panel = document.getElementById('mainPanel');
   if (!selectedTool) {
     panel.innerHTML = `<div class="empty-state">
+      <svg class="pokeball" viewBox="0 0 100 100" fill="none" stroke="currentColor" stroke-width="3">
+        <circle cx="50" cy="50" r="46"/>
+        <line x1="4" y1="50" x2="34" y2="50"/>
+        <line x1="66" y1="50" x2="96" y2="50"/>
+        <circle cx="50" cy="50" r="16"/>
+        <circle cx="50" cy="50" r="8" fill="currentColor" opacity="0.3"/>
+      </svg>
       <p>Select a tool from the sidebar</p>
     </div>`;
     return;
@@ -448,6 +555,21 @@ function renderField(name, prop, isRequired) {
   const isOptional = !isRequired;
   const optLabel = isOptional ? ' <span class="optional">(optional)</span>' : '';
   const typeLabel = `<span class="field-type">${type}</span>`;
+
+  // Enum dropdown
+  if (prop.enum && Array.isArray(prop.enum)) {
+    const options = prop.enum.map(v =>
+      `<option value="${escapeHtml(String(v))}">${escapeHtml(String(v))}</option>`
+    ).join('');
+    return `<div class="field">
+      <label for="field-${name}">${name}${typeLabel}${optLabel}</label>
+      ${desc ? `<span class="field-desc">${escapeHtml(desc)}</span>` : ''}
+      <select id="field-${name}" data-field="${name}" data-type="enum">
+        <option value="">-- select --</option>
+        ${options}
+      </select>
+    </div>`;
+  }
 
   if (type === 'boolean') {
     return `<div class="field field-checkbox">
@@ -504,6 +626,12 @@ function collectArgs() {
       continue;
     }
 
+    if (type === 'enum') {
+      const val = el.value;
+      if (val) args[name] = val;
+      continue;
+    }
+
     const val = el.value.trim();
     if (!val) continue;
 
@@ -534,7 +662,7 @@ async function callTool() {
     const res = await fetch(`${API}/api/call`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tool: selectedTool.name, arguments: args }),
+      body: JSON.stringify({ server: currentServer, tool: selectedTool.name, arguments: args }),
     });
     lastResult = await res.json();
     lastDuration = Math.round(performance.now() - start);
@@ -621,7 +749,7 @@ document.addEventListener('keydown', e => {
   if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) callTool();
 });
 
-fetchTools();
+init();
 </script>
 </body>
 </html>

--- a/src/mcp/debug-ui.ts
+++ b/src/mcp/debug-ui.ts
@@ -2,9 +2,14 @@
 /**
  * MCP Debug Web UI
  *
- * Spawns the Pokédex MCP server as a child process, connects to it via
+ * Spawns one or more MCP servers as child processes, connects to them via
  * the MCP client SDK over stdio, and serves a browser-based tool explorer
  * at http://localhost:3333 (configurable via PORT env var).
+ *
+ * Usage:
+ *   npx tsx src/mcp/debug-ui.ts            # pokedex server (default)
+ *   npx tsx src/mcp/debug-ui.ts porymap    # porymap server
+ *   npx tsx src/mcp/debug-ui.ts all        # both servers
  */
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -17,18 +22,63 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = parseInt(process.env.PORT ?? "3333", 10);
 
-async function createMcpClient(): Promise<Client> {
+// ─── Server Registry ────────────────────────────────────────────────────────
+
+interface ServerConfig {
+  key: string;
+  label: string;
+  scriptPath: string;
+  description: string;
+}
+
+const SERVER_REGISTRY: ServerConfig[] = [
+  {
+    key: "pokedex",
+    label: "Pokédex",
+    scriptPath: "pokedex-server.ts",
+    description: "Pokémon game data (stats, moves, types, sets)",
+  },
+  {
+    key: "porymap",
+    label: "Porymap",
+    scriptPath: "porymap-server.ts",
+    description: "Map data inspection (layouts, events, tilesets)",
+  },
+];
+
+// ─── CLI Argument Parsing ───────────────────────────────────────────────────
+
+const arg = process.argv[2] ?? "pokedex";
+const requestedServers =
+  arg === "all"
+    ? SERVER_REGISTRY
+    : SERVER_REGISTRY.filter((s) => s.key === arg);
+
+if (requestedServers.length === 0) {
+  const keys = SERVER_REGISTRY.map((s) => s.key).join(", ");
+  console.error(`Unknown server: "${arg}". Available: ${keys}, all`);
+  process.exit(1);
+}
+
+// ─── MCP Client ─────────────────────────────────────────────────────────────
+
+async function createMcpClient(config: ServerConfig): Promise<Client> {
   const transport = new StdioClientTransport({
     command: "npx",
-    args: ["tsx", path.resolve(__dirname, "pokedex-server.ts")],
+    args: ["tsx", path.resolve(__dirname, config.scriptPath)],
     cwd: path.resolve(__dirname, "../.."),
     stderr: "inherit",
   });
 
-  const client = new Client({ name: "debug-ui", version: "1.0.0" });
+  const client = new Client({
+    name: `debug-ui-${config.key}`,
+    version: "1.0.0",
+  });
   await client.connect(transport);
   return client;
 }
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
 
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -47,10 +97,28 @@ function json(res: http.ServerResponse, data: unknown, status = 200) {
   res.end(JSON.stringify(data));
 }
 
+// ─── Main ───────────────────────────────────────────────────────────────────
+
 async function main() {
-  console.log("Connecting to Pokédex MCP server...");
-  const client = await createMcpClient();
-  console.log("MCP client connected.");
+  const clients = new Map<
+    string,
+    { client: Client; config: ServerConfig }
+  >();
+
+  for (const config of requestedServers) {
+    console.log(`Connecting to ${config.label} MCP server...`);
+    const client = await createMcpClient(config);
+    clients.set(config.key, { client, config });
+    console.log(`${config.label} connected.`);
+  }
+
+  function resolveClient(serverKey: string | undefined) {
+    if (clients.size === 1 && !serverKey) {
+      return clients.values().next().value!;
+    }
+    if (!serverKey) return undefined;
+    return clients.get(serverKey);
+  }
 
   const htmlPath = path.resolve(__dirname, "debug-ui.html");
 
@@ -75,15 +143,43 @@ async function main() {
         return;
       }
 
+      // List connected servers
+      if (url.pathname === "/api/servers" && req.method === "GET") {
+        const serverList = Array.from(clients.values()).map(({ config }) => ({
+          key: config.key,
+          label: config.label,
+          description: config.description,
+        }));
+        json(res, serverList);
+        return;
+      }
+
+      // List tools for a server
       if (url.pathname === "/api/tools" && req.method === "GET") {
-        const result = await client.listTools();
+        const serverKey = url.searchParams.get("server") ?? undefined;
+        const entry = resolveClient(serverKey);
+        if (!entry) {
+          json(
+            res,
+            { error: "Missing or invalid 'server' query parameter" },
+            400,
+          );
+          return;
+        }
+        const result = await entry.client.listTools();
         json(res, result.tools);
         return;
       }
 
+      // Call a tool
       if (url.pathname === "/api/call" && req.method === "POST") {
         const body = JSON.parse(await readBody(req));
-        const { tool, arguments: args } = body as {
+        const {
+          server: serverKey,
+          tool,
+          arguments: args,
+        } = body as {
+          server?: string;
           tool: string;
           arguments: Record<string, unknown>;
         };
@@ -93,7 +189,17 @@ async function main() {
           return;
         }
 
-        const result = await client.callTool({
+        const entry = resolveClient(serverKey);
+        if (!entry) {
+          json(
+            res,
+            { error: "Missing or invalid 'server' field" },
+            400,
+          );
+          return;
+        }
+
+        const result = await entry.client.callTool({
           name: tool,
           arguments: args ?? {},
         });
@@ -112,13 +218,18 @@ async function main() {
   });
 
   server.listen(PORT, () => {
-    console.log(`\nMCP Debug UI: http://localhost:${PORT}\n`);
+    const serverNames = Array.from(clients.values())
+      .map(({ config }) => config.label)
+      .join(" + ");
+    console.log(`\nMCP Debug UI (${serverNames}): http://localhost:${PORT}\n`);
   });
 
   const shutdown = async () => {
     console.log("\nShutting down...");
     server.close();
-    await client.close();
+    for (const { client } of clients.values()) {
+      await client.close();
+    }
     process.exit(0);
   };
   process.on("SIGINT", shutdown);


### PR DESCRIPTION
The debug UI previously only supported the pokedex MCP server. This extends
it to support any registered MCP server via CLI argument selection and adds
a server tab switcher in the frontend for multi-server mode.

- Add ServerConfig registry and CLI arg parsing (pokedex/porymap/all)
- Add /api/servers endpoint for frontend server discovery
- Add server query param to /api/tools and server field to /api/call
- Add server tab bar in HTML (auto-hidden in single-server mode)
- Add enum dropdown rendering for tool parameters
- Add npm scripts: debug:mcp:porymap, debug:mcp:all

https://claude.ai/code/session_01BJsRLLpABAUgtE2kW1P4bY