### PR TITLE
Add Pokedex page to docs website with full Pokemon data

### DIFF
--- a/docs/build-scripts/build-pokedex.mjs
+++ b/docs/build-scripts/build-pokedex.mjs
@@ -1,0 +1,728 @@
+#!/usr/bin/env node
+
+/**
+ * Build script: parses pokeemerald source data files into docs/public/data/pokedex.json
+ * Extracts species info, learnsets, evolution, encounters, and move data.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DOCS_DIR = join(__dirname, '..');
+const ROOT = join(DOCS_DIR, '..');
+const POKE = join(ROOT, 'pokeemerald');
+const OUTPUT_DIR = join(DOCS_DIR, 'public', 'data');
+const OUTPUT_FILE = join(OUTPUT_DIR, 'pokedex.json');
+
+// ── Helpers ──
+
+/** SPECIES_TRAPINCH → Trapinch */
+function formatSpecies(raw) {
+  return raw
+    .replace(/^SPECIES_/, '')
+    .split('_')
+    .map(w => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/** MOVE_ROCK_THROW → Rock Throw */
+function formatMove(raw) {
+  if (!raw || raw === 'MOVE_NONE') return null;
+  return raw
+    .replace(/^MOVE_/, '')
+    .split('_')
+    .map(w => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/** ITEM_ORAN_BERRY → Oran Berry, ITEM_NONE → null */
+function formatItem(raw) {
+  if (!raw || raw === 'ITEM_NONE') return null;
+  return raw
+    .replace(/^ITEM_/, '')
+    .split('_')
+    .map(w => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/** ABILITY_OVERGROW → Overgrow, ABILITY_NONE → null */
+function formatAbility(raw) {
+  if (!raw || raw === 'ABILITY_NONE') return null;
+  return raw
+    .replace(/^ABILITY_/, '')
+    .split('_')
+    .map(w => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/** EGG_GROUP_MONSTER → Monster */
+function formatEggGroup(raw) {
+  if (!raw || raw === 'EGG_GROUP_UNDISCOVERED' || raw === 'EGG_GROUP_NO_EGGS_DISCOVERED') return 'Undiscovered';
+  return raw
+    .replace(/^EGG_GROUP_/, '')
+    .split('_')
+    .map(w => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/** GROWTH_MEDIUM_SLOW → Medium Slow */
+function formatGrowthRate(raw) {
+  if (!raw) return 'Medium Fast';
+  return raw
+    .replace(/^GROWTH_/, '')
+    .split('_')
+    .map(w => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/** TYPE_GRASS → Grass */
+function formatType(raw) {
+  if (!raw) return 'Normal';
+  const t = raw.replace(/^TYPE_/, '');
+  return t.charAt(0) + t.slice(1).toLowerCase();
+}
+
+/** MAP_ROUTE101 → Route 101 */
+function formatMapName(raw) {
+  const s = raw.replace(/^MAP_/, '');
+  const routeMatch = s.match(/^ROUTE(\d+)$/);
+  if (routeMatch) return `Route ${routeMatch[1]}`;
+  return s
+    .split('_')
+    .map(w => w.charAt(0) + w.slice(1).toLowerCase())
+    .join(' ');
+}
+
+/** Parse gender ratio constant to human-readable string */
+function formatGenderRatio(raw) {
+  if (!raw) return 'Unknown';
+  if (raw.includes('MON_GENDERLESS')) return 'Genderless';
+  if (raw.includes('MON_MALE')) return '100% Male';
+  if (raw.includes('MON_FEMALE')) return '100% Female';
+  const m = raw.match(/PERCENT_FEMALE\(\s*([\d.]+)\s*\)/);
+  if (m) {
+    const female = parseFloat(m[1]);
+    return `${(100 - female).toFixed(1)}% M / ${female.toFixed(1)}% F`;
+  }
+  return 'Unknown';
+}
+
+// ── National Dex Order ──
+
+async function parseNationalDexOrder() {
+  const src = await readFile(join(POKE, 'include/constants/pokedex.h'), 'utf-8');
+  const order = new Map();
+  let idx = 0;
+  for (const m of src.matchAll(/NATIONAL_DEX_(\w+)/g)) {
+    if (m[1] === 'NONE') { idx++; continue; }
+    order.set('SPECIES_' + m[1], idx);
+    idx++;
+  }
+  return order;
+}
+
+// ── Species Info ──
+
+async function parseSpeciesInfo() {
+  const src = await readFile(join(POKE, 'src/data/pokemon/species_info.h'), 'utf-8');
+
+  const species = [];
+  // Match each [SPECIES_X] = { ... } block
+  const blockRe = /\[SPECIES_(\w+)\]\s*=\s*\{([\s\S]*?)\},?\s*(?=\[SPECIES_|\z|$)/g;
+  // Alternative: split by [SPECIES_ markers
+  const parts = src.split(/(?=\[SPECIES_\w+\]\s*=)/);
+
+  for (const part of parts) {
+    const headerMatch = part.match(/\[SPECIES_(\w+)\]\s*=/);
+    if (!headerMatch) continue;
+    const name = headerMatch[1];
+    if (name === 'NONE' || name.startsWith('OLD_UNOWN')) continue;
+    // Skip Unown forms (UNOWN_B through UNOWN_Z, UNOWN_EMARK, UNOWN_QMARK)
+    if (/^UNOWN_[A-Z]$/.test(name) || name === 'UNOWN_EMARK' || name === 'UNOWN_QMARK') continue;
+
+    const specConst = 'SPECIES_' + name;
+    const block = part;
+
+    const getField = (field) => {
+      const m = block.match(new RegExp(`\\.${field}\\s*=\\s*([^,}]+)`));
+      return m ? m[1].trim() : null;
+    };
+
+    const getNumField = (field) => {
+      const v = getField(field);
+      return v ? parseInt(v, 10) : 0;
+    };
+
+    const typesMatch = block.match(/\.types\s*=\s*\{\s*(TYPE_\w+)\s*,\s*(TYPE_\w+)\s*\}/);
+    const type1 = typesMatch ? formatType(typesMatch[1]) : 'Normal';
+    const type2 = typesMatch ? formatType(typesMatch[2]) : type1;
+
+    const eggMatch = block.match(/\.eggGroups\s*=\s*\{\s*(EGG_GROUP_\w+)\s*,\s*(EGG_GROUP_\w+)\s*,?\s*\}/);
+    const egg1 = eggMatch ? formatEggGroup(eggMatch[1]) : 'Undiscovered';
+    const egg2 = eggMatch ? formatEggGroup(eggMatch[2]) : egg1;
+
+    const abilMatch = block.match(/\.abilities\s*=\s*\{(.*?)\}/s);
+    const abilities = [];
+    if (abilMatch) {
+      for (const am of abilMatch[1].matchAll(/ABILITY_\w+/g)) {
+        const a = formatAbility(am[0]);
+        if (a && !abilities.includes(a)) abilities.push(a);
+      }
+    }
+
+    const hp = getNumField('baseHP');
+    const atk = getNumField('baseAttack');
+    const def = getNumField('baseDefense');
+    const spa = getNumField('baseSpAttack');
+    const spd = getNumField('baseSpDefense');
+    const spe = getNumField('baseSpeed');
+
+    species.push({
+      speciesConstant: specConst,
+      name: formatSpecies(specConst),
+      types: type1 === type2 ? [type1] : [type1, type2],
+      stats: { hp, atk, def, spa, spd, spe },
+      bst: hp + atk + def + spa + spd + spe,
+      abilities,
+      catchRate: getNumField('catchRate'),
+      genderRatio: formatGenderRatio(getField('genderRatio')),
+      eggGroups: egg1 === egg2 ? [egg1] : [egg1, egg2],
+      growthRate: formatGrowthRate(getField('growthRate')),
+      evYield: {
+        hp: getNumField('evYield_HP'),
+        atk: getNumField('evYield_Attack'),
+        def: getNumField('evYield_Defense'),
+        spa: getNumField('evYield_SpAttack'),
+        spd: getNumField('evYield_SpDefense'),
+        spe: getNumField('evYield_Speed'),
+      },
+      heldItems: {
+        common: formatItem(getField('itemCommon')),
+        rare: formatItem(getField('itemRare')),
+      },
+    });
+  }
+
+  return species;
+}
+
+// ── Pokedex Entries (category, height, weight) ──
+
+async function parsePokedexEntries() {
+  const src = await readFile(join(POKE, 'src/data/pokemon/pokedex_entries.h'), 'utf-8');
+  const entries = new Map();
+  const parts = src.split(/(?=\[NATIONAL_DEX_\w+\]\s*=)/);
+
+  for (const part of parts) {
+    const headerMatch = part.match(/\[NATIONAL_DEX_(\w+)\]\s*=/);
+    if (!headerMatch || headerMatch[1] === 'NONE') continue;
+
+    const specConst = 'SPECIES_' + headerMatch[1];
+    const catMatch = part.match(/\.categoryName\s*=\s*_\("([^"]+)"\)/);
+    const heightMatch = part.match(/\.height\s*=\s*(\d+)/);
+    const weightMatch = part.match(/\.weight\s*=\s*(\d+)/);
+
+    entries.set(specConst, {
+      category: catMatch ? catMatch[1].charAt(0) + catMatch[1].slice(1).toLowerCase() : 'Unknown',
+      height: heightMatch ? parseInt(heightMatch[1], 10) / 10 : 0, // decimeters → meters
+      weight: weightMatch ? parseInt(weightMatch[1], 10) / 10 : 0, // hectograms → kg
+    });
+  }
+
+  return entries;
+}
+
+// ── Pokedex Descriptions ──
+
+async function parsePokedexText() {
+  const src = await readFile(join(POKE, 'src/data/pokemon/pokedex_text.h'), 'utf-8');
+  const descriptions = new Map();
+
+  // Match: const u8 gBulbasaurPokedexText[] = _("...");
+  const re = /const\s+u8\s+g(\w+)PokedexText\[\]\s*=\s*_\(\s*([\s\S]*?)\);/g;
+  for (const m of src.matchAll(re)) {
+    const name = m[1]; // e.g. "Bulbasaur"
+    // Extract text from _("...") with potential multi-line strings
+    const text = m[2]
+      .replace(/"/g, '')
+      .replace(/\n\s*/g, ' ')
+      .replace(/\\n/g, ' ')
+      .trim();
+    // Convert name to SPECIES_ constant
+    const specConst = 'SPECIES_' + name.replace(/([A-Z])/g, '_$1').toUpperCase().replace(/^_/, '');
+    descriptions.set(name.toUpperCase(), text);
+  }
+
+  return descriptions;
+}
+
+// ── Level-Up Learnsets ──
+
+async function parseLevelUpLearnsets() {
+  const src = await readFile(join(POKE, 'src/data/pokemon/level_up_learnsets.h'), 'utf-8');
+  const learnsets = new Map();
+
+  // Match each static const u16 sXxxLevelUpLearnset[] = { ... };
+  const blockRe = /static\s+const\s+u16\s+s(\w+)LevelUpLearnset\[\]\s*=\s*\{([\s\S]*?)\};/g;
+  for (const m of src.matchAll(blockRe)) {
+    const varName = m[1]; // e.g. "Bulbasaur"
+    const body = m[2];
+    const moves = [];
+
+    for (const mm of body.matchAll(/LEVEL_UP_MOVE\(\s*(\d+)\s*,\s*(MOVE_\w+)\s*\)/g)) {
+      const level = parseInt(mm[1], 10);
+      const move = formatMove(mm[2]);
+      if (move) moves.push({ level, move });
+    }
+
+    learnsets.set(varName.toUpperCase(), moves);
+  }
+
+  return learnsets;
+}
+
+// ── TM/HM List ──
+
+async function parseTMHMList() {
+  const src = await readFile(join(POKE, 'include/constants/tms_hms.h'), 'utf-8');
+  const tms = [];
+  const hms = [];
+
+  // Parse FOREACH_TM
+  const tmMatch = src.match(/FOREACH_TM\(F\)\s*\\([\s\S]*?)(?=\n\n|#define FOREACH_HM)/);
+  if (tmMatch) {
+    for (const m of tmMatch[0].matchAll(/F\((\w+)\)/g)) {
+      tms.push(m[1]);
+    }
+  }
+
+  // Parse FOREACH_HM
+  const hmMatch = src.match(/FOREACH_HM\(F\)\s*\\([\s\S]*?)(?=\n\n|#define FOREACH_TMHM)/);
+  if (hmMatch) {
+    for (const m of hmMatch[0].matchAll(/F\((\w+)\)/g)) {
+      hms.push(m[1]);
+    }
+  }
+
+  return { tms, hms };
+}
+
+// ── TM/HM Learnsets ──
+
+async function parseTMHMLearnsets() {
+  const src = await readFile(join(POKE, 'src/data/pokemon/tmhm_learnsets.h'), 'utf-8');
+  const learnsets = new Map();
+
+  const parts = src.split(/(?=\[SPECIES_\w+\]\s*=)/);
+  for (const part of parts) {
+    const headerMatch = part.match(/\[SPECIES_(\w+)\]\s*=/);
+    if (!headerMatch || headerMatch[1] === 'NONE') continue;
+
+    const specName = headerMatch[1];
+    const learned = [];
+
+    // Match .MOVE_NAME = TRUE patterns
+    for (const m of part.matchAll(/\.(\w+)\s*=\s*TRUE/g)) {
+      learned.push(m[1]);
+    }
+
+    learnsets.set(specName, learned);
+  }
+
+  return learnsets;
+}
+
+// ── Tutor Learnsets ──
+
+async function parseTutorLearnsets() {
+  const src = await readFile(join(POKE, 'src/data/pokemon/tutor_learnsets.h'), 'utf-8');
+  const learnsets = new Map();
+
+  const parts = src.split(/(?=\[SPECIES_\w+\]\s*=)/);
+  for (const part of parts) {
+    const headerMatch = part.match(/\[SPECIES_(\w+)\]\s*=/);
+    if (!headerMatch || headerMatch[1] === 'NONE') continue;
+
+    const specName = headerMatch[1];
+    const moves = [];
+
+    for (const m of part.matchAll(/TUTOR\(MOVE_(\w+)\)/g)) {
+      const moveName = m[1].split('_').map(w => w.charAt(0) + w.slice(1).toLowerCase()).join(' ');
+      moves.push(moveName);
+    }
+
+    learnsets.set(specName, moves);
+  }
+
+  return learnsets;
+}
+
+// ── Egg Moves ──
+
+async function parseEggMoves() {
+  const src = await readFile(join(POKE, 'src/data/pokemon/egg_moves.h'), 'utf-8');
+  const eggMoves = new Map();
+
+  // Pattern: egg_moves(SPECIES_NAME, MOVE_X, MOVE_Y, ...)
+  const re = /egg_moves\(\s*(\w+)\s*,([\s\S]*?)(?=egg_moves\(|$)/g;
+  for (const m of src.matchAll(re)) {
+    const specName = m[1];
+    const moves = [];
+    for (const mm of m[2].matchAll(/MOVE_(\w+)/g)) {
+      const moveName = mm[1].split('_').map(w => w.charAt(0) + w.slice(1).toLowerCase()).join(' ');
+      moves.push(moveName);
+    }
+    eggMoves.set(specName, moves);
+  }
+
+  return eggMoves;
+}
+
+// ── Evolution Data ──
+
+async function parseEvolution() {
+  const src = await readFile(join(POKE, 'src/data/pokemon/evolution.h'), 'utf-8');
+  const evolutions = new Map(); // species → [{method, param, target}]
+
+  const parts = src.split(/(?=\[SPECIES_\w+\]\s*=)/);
+  for (const part of parts) {
+    const headerMatch = part.match(/\[SPECIES_(\w+)\]\s*=/);
+    if (!headerMatch) continue;
+
+    const specConst = 'SPECIES_' + headerMatch[1];
+    const evos = [];
+
+    // Match {EVO_METHOD, PARAM, SPECIES_TARGET}
+    for (const m of part.matchAll(/\{\s*(EVO_\w+)\s*,\s*(\w+)\s*,\s*(SPECIES_\w+)\s*\}/g)) {
+      const method = m[1];
+      const param = m[2];
+      const target = m[3];
+
+      let methodStr;
+      switch (method) {
+        case 'EVO_LEVEL':
+          methodStr = `Level ${param}`;
+          break;
+        case 'EVO_ITEM':
+          methodStr = formatItem(param) || param;
+          break;
+        case 'EVO_TRADE':
+          methodStr = 'Trade';
+          break;
+        case 'EVO_TRADE_ITEM':
+          methodStr = `Trade holding ${formatItem(param) || param}`;
+          break;
+        case 'EVO_FRIENDSHIP':
+          methodStr = 'Friendship';
+          break;
+        case 'EVO_FRIENDSHIP_DAY':
+          methodStr = 'Friendship (Day)';
+          break;
+        case 'EVO_FRIENDSHIP_NIGHT':
+          methodStr = 'Friendship (Night)';
+          break;
+        case 'EVO_LEVEL_ATK_GT_DEF':
+          methodStr = `Level ${param} (Atk > Def)`;
+          break;
+        case 'EVO_LEVEL_DEF_GT_ATK':
+          methodStr = `Level ${param} (Def > Atk)`;
+          break;
+        case 'EVO_LEVEL_ATK_EQ_DEF':
+          methodStr = `Level ${param} (Atk = Def)`;
+          break;
+        case 'EVO_BEAUTY':
+          methodStr = `Beauty (${param}+)`;
+          break;
+        default:
+          methodStr = method.replace('EVO_', '');
+      }
+
+      evos.push({ method: methodStr, target: formatSpecies(target), targetConst: target });
+    }
+
+    if (evos.length > 0) {
+      evolutions.set(specConst, evos);
+    }
+  }
+
+  return evolutions;
+}
+
+// ── Wild Encounters ──
+
+async function parseEncounters() {
+  const src = await readFile(join(POKE, 'src/data/wild_encounters.json'), 'utf-8');
+  const data = JSON.parse(src);
+
+  const LAND_RATES = [20, 20, 10, 10, 10, 10, 5, 5, 4, 4, 1, 1];
+  const WATER_RATES = [60, 30, 5, 4, 1];
+  const ROCK_SMASH_RATES = [60, 30, 5, 4, 1];
+  const FISHING_RATES = [70, 30, 60, 20, 20, 40, 40, 15, 4, 1];
+
+  // species → [{map, method, minLevel, maxLevel, rate}]
+  const encounters = new Map();
+
+  function addEncounter(specConst, map, method, minLevel, maxLevel, rate) {
+    const name = formatSpecies(specConst);
+    if (!encounters.has(name)) encounters.set(name, []);
+    // Avoid duplicates
+    const existing = encounters.get(name);
+    const dup = existing.find(e => e.map === map && e.method === method && e.minLevel === minLevel && e.maxLevel === maxLevel);
+    if (!dup) {
+      existing.push({ map, method, minLevel, maxLevel, rate });
+    }
+  }
+
+  for (const group of (data.wild_encounter_groups || [])) {
+    for (const entry of (group.encounters || [])) {
+      if (!entry.map) continue;
+      const mapName = formatMapName(entry.map);
+
+      if (entry.land_mons) {
+        entry.land_mons.mons.forEach((mon, i) => {
+          addEncounter(mon.species, mapName, 'Grass', mon.min_level, mon.max_level, LAND_RATES[i] || 0);
+        });
+      }
+      if (entry.water_mons) {
+        entry.water_mons.mons.forEach((mon, i) => {
+          addEncounter(mon.species, mapName, 'Surfing', mon.min_level, mon.max_level, WATER_RATES[i] || 0);
+        });
+      }
+      if (entry.rock_smash_mons) {
+        entry.rock_smash_mons.mons.forEach((mon, i) => {
+          addEncounter(mon.species, mapName, 'Rock Smash', mon.min_level, mon.max_level, ROCK_SMASH_RATES[i] || 0);
+        });
+      }
+      if (entry.fishing_mons) {
+        entry.fishing_mons.mons.forEach((mon, i) => {
+          let method = 'Fishing';
+          if (i < 2) method = 'Old Rod';
+          else if (i < 5) method = 'Good Rod';
+          else method = 'Super Rod';
+          addEncounter(mon.species, mapName, method, mon.min_level, mon.max_level, FISHING_RATES[i] || 0);
+        });
+      }
+    }
+  }
+
+  return encounters;
+}
+
+// ── Battle Moves ──
+
+async function parseBattleMoves() {
+  const src = await readFile(join(POKE, 'src/data/battle_moves.h'), 'utf-8');
+  const moves = {};
+
+  const parts = src.split(/(?=\[MOVE_\w+\]\s*=)/);
+  for (const part of parts) {
+    const headerMatch = part.match(/\[MOVE_(\w+)\]\s*=/);
+    if (!headerMatch || headerMatch[1] === 'NONE') continue;
+
+    const moveName = headerMatch[1].split('_').map(w => w.charAt(0) + w.slice(1).toLowerCase()).join(' ');
+
+    const getField = (field) => {
+      const m = part.match(new RegExp(`\\.${field}\\s*=\\s*([^,}\\n]+)`));
+      return m ? m[1].trim() : null;
+    };
+
+    const typeRaw = getField('type');
+    const categoryRaw = getField('category');
+
+    moves[moveName] = {
+      type: typeRaw ? formatType(typeRaw) : 'Normal',
+      power: parseInt(getField('power') || '0', 10),
+      accuracy: parseInt(getField('accuracy') || '0', 10),
+      pp: parseInt(getField('pp') || '0', 10),
+      category: categoryRaw
+        ? categoryRaw.replace('MOVE_CATEGORY_', '').charAt(0) + categoryRaw.replace('MOVE_CATEGORY_', '').slice(1).toLowerCase()
+        : 'Status',
+    };
+  }
+
+  return moves;
+}
+
+// ── Learnset Pointer Mapping ──
+// Maps variable name (e.g. "BULBASAUR") used in learnsets to SPECIES_ constant
+
+async function parseLearnsetPointers() {
+  const src = await readFile(join(POKE, 'src/data/pokemon/level_up_learnset_pointers.h'), 'utf-8');
+  const map = new Map();
+
+  // [SPECIES_BULBASAUR] = sBulbasaurLevelUpLearnset,
+  for (const m of src.matchAll(/\[SPECIES_(\w+)\]\s*=\s*s(\w+)LevelUpLearnset/g)) {
+    map.set(m[2].toUpperCase(), 'SPECIES_' + m[1]);
+  }
+
+  return map;
+}
+
+// ── Main ──
+
+async function main() {
+  console.log('Building pokedex.json...');
+
+  const [
+    speciesList,
+    dexEntries,
+    dexTexts,
+    levelUpLearnsets,
+    { tms, hms },
+    tmhmLearnsets,
+    tutorLearnsets,
+    eggMoves,
+    evolutionData,
+    encounterData,
+    battleMoves,
+    nationalDexOrder,
+    learnsetPointers,
+  ] = await Promise.all([
+    parseSpeciesInfo(),
+    parsePokedexEntries(),
+    parsePokedexText(),
+    parseLevelUpLearnsets(),
+    parseTMHMList(),
+    parseTMHMLearnsets(),
+    parseTutorLearnsets(),
+    parseEggMoves(),
+    parseEvolution(),
+    parseEncounters(),
+    parseBattleMoves(),
+    parseNationalDexOrder(),
+    parseLearnsetPointers(),
+  ]);
+
+  // Build TM/HM move name mapping
+  const tmhmMoveNames = [...tms, ...hms].map(id =>
+    id.split('_').map(w => w.charAt(0) + w.slice(1).toLowerCase()).join(' ')
+  );
+
+  // Build TM number labels
+  const tmLabels = {};
+  tms.forEach((id, i) => {
+    const moveName = id.split('_').map(w => w.charAt(0) + w.slice(1).toLowerCase()).join(' ');
+    tmLabels[id] = `TM${String(i + 1).padStart(2, '0')}`;
+  });
+  hms.forEach((id, i) => {
+    const moveName = id.split('_').map(w => w.charAt(0) + w.slice(1).toLowerCase()).join(' ');
+    tmLabels[id] = `HM${String(i + 1).padStart(2, '0')}`;
+  });
+
+  // Build reverse evolution map (who evolves INTO this species)
+  const evolvesFromMap = new Map();
+  for (const [fromConst, evos] of evolutionData.entries()) {
+    for (const evo of evos) {
+      evolvesFromMap.set(evo.targetConst, { from: formatSpecies(fromConst), method: evo.method });
+    }
+  }
+
+  // Assemble pokemon entries
+  const pokemon = [];
+
+  for (const sp of speciesList) {
+    const specConst = sp.speciesConstant;
+    const specName = specConst.replace('SPECIES_', '');
+
+    // National dex ID
+    const dexId = nationalDexOrder.get(specConst) || 0;
+    if (dexId === 0) continue; // Skip if not in national dex
+
+    // Pokedex entry data
+    const dexEntry = dexEntries.get(specConst) || {};
+
+    // Description text - try matching by species name
+    const nameUpper = sp.name.replace(/\s/g, '').toUpperCase();
+    let description = dexTexts.get(nameUpper) || dexTexts.get(specName) || '';
+
+    // Level-up learnset - find via pointer mapping or direct name match
+    let levelUp = [];
+    // Try direct match first
+    if (levelUpLearnsets.has(specName)) {
+      levelUp = levelUpLearnsets.get(specName);
+    } else {
+      // Try via pointer mapping
+      for (const [varName, mappedConst] of learnsetPointers.entries()) {
+        if (mappedConst === specConst && levelUpLearnsets.has(varName)) {
+          levelUp = levelUpLearnsets.get(varName);
+          break;
+        }
+      }
+    }
+
+    // TM/HM learnset
+    const tmhmLearned = tmhmLearnsets.get(specName) || [];
+    const tmhmMoves = tmhmLearned.map(id => {
+      const moveName = id.split('_').map(w => w.charAt(0) + w.slice(1).toLowerCase()).join(' ');
+      const label = tmLabels[id] || '';
+      return { label, move: moveName };
+    });
+
+    // Tutor learnset
+    const tutorMoves = tutorLearnsets.get(specName) || [];
+
+    // Egg moves
+    const eggs = eggMoves.get(specName) || [];
+
+    // Evolution
+    const evosTo = evolutionData.get(specConst) || [];
+    const evoFrom = evolvesFromMap.get(specConst) || null;
+
+    // Locations
+    const locations = encounterData.get(sp.name) || [];
+
+    pokemon.push({
+      id: dexId,
+      name: sp.name,
+      types: sp.types,
+      stats: sp.stats,
+      bst: sp.bst,
+      abilities: sp.abilities,
+      category: dexEntry.category || 'Unknown',
+      height: dexEntry.height || 0,
+      weight: dexEntry.weight || 0,
+      description,
+      catchRate: sp.catchRate,
+      genderRatio: sp.genderRatio,
+      eggGroups: sp.eggGroups,
+      growthRate: sp.growthRate,
+      evYield: sp.evYield,
+      heldItems: sp.heldItems,
+      learnset: {
+        levelUp,
+        tmhm: tmhmMoves,
+        tutor: tutorMoves,
+        egg: eggs,
+      },
+      evolution: {
+        evolvesFrom: evoFrom,
+        evolvesTo: evosTo.map(e => ({ species: e.target, method: e.method })),
+      },
+      locations,
+    });
+  }
+
+  // Sort by national dex number
+  pokemon.sort((a, b) => a.id - b.id);
+
+  const output = {
+    generatedAt: new Date().toISOString(),
+    pokemon,
+    moves: battleMoves,
+  };
+
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  await writeFile(OUTPUT_FILE, JSON.stringify(output) + '\n');
+
+  console.log(`✔ Generated ${OUTPUT_FILE}`);
+  console.log(`  Pokemon: ${pokemon.length}`);
+  console.log(`  Moves: ${Object.keys(battleMoves).length}`);
+  console.log(`  File size: ${(JSON.stringify(output).length / 1024).toFixed(0)} KB`);
+}
+
+main().catch(err => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,1922 @@
+{
+  "name": "agent-oak-docs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agent-oak-docs",
+      "version": "1.0.0",
+      "dependencies": {
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+        "react-router-dom": "^7.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/react": "^18.3.0",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        "typescript": "^5.7.0",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
+      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001784",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
+      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.331",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
+      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
+      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
+      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build:data": "node build-scripts/build-journals.mjs && node build-scripts/build-game-guide.mjs && node build-scripts/build-releases.mjs",
+    "build:data": "node build-scripts/build-journals.mjs && node build-scripts/build-game-guide.mjs && node build-scripts/build-releases.mjs && node build-scripts/build-pokedex.mjs",
     "build": "npm run build:data && vite build",
     "preview": "vite preview"
   },

--- a/docs/src/components/EvolutionChain.tsx
+++ b/docs/src/components/EvolutionChain.tsx
@@ -1,0 +1,83 @@
+import PokemonSprite from './PokemonSprite';
+import type { PokedexEntry } from '../lib/types';
+
+interface EvolutionChainProps {
+  pokemon: PokedexEntry;
+  allPokemon: PokedexEntry[];
+  onNavigate: (name: string) => void;
+}
+
+interface ChainNode {
+  name: string;
+  method?: string;
+}
+
+function buildChain(pokemon: PokedexEntry, allPokemon: PokedexEntry[]): ChainNode[][] {
+  const stages: ChainNode[][] = [];
+
+  // Walk back to the base form
+  let base = pokemon;
+  const visited = new Set<string>();
+  while (base.evolution.evolvesFrom && !visited.has(base.name)) {
+    visited.add(base.name);
+    const prev = allPokemon.find(p => p.name === base.evolution.evolvesFrom!.from);
+    if (!prev) break;
+    base = prev;
+  }
+
+  // Build forward from base
+  const queue: { mon: PokedexEntry; stage: number; method?: string }[] = [
+    { mon: base, stage: 0 },
+  ];
+  const seen = new Set<string>();
+
+  while (queue.length > 0) {
+    const { mon, stage, method } = queue.shift()!;
+    if (seen.has(mon.name)) continue;
+    seen.add(mon.name);
+
+    if (!stages[stage]) stages[stage] = [];
+    stages[stage].push({ name: mon.name, method });
+
+    for (const evo of mon.evolution.evolvesTo) {
+      const next = allPokemon.find(p => p.name === evo.species);
+      if (next) {
+        queue.push({ mon: next, stage: stage + 1, method: evo.method });
+      }
+    }
+  }
+
+  return stages;
+}
+
+export default function EvolutionChain({ pokemon, allPokemon, onNavigate }: EvolutionChainProps) {
+  const stages = buildChain(pokemon, allPokemon);
+
+  if (stages.length <= 1 && stages[0]?.length <= 1) {
+    return <p className="evo-none">This Pokemon does not evolve.</p>;
+  }
+
+  return (
+    <div className="evo-chain">
+      {stages.map((stage, i) => (
+        <div key={i} className="evo-stage">
+          {i > 0 && <span className="evo-arrow">→</span>}
+          <div className="evo-stage-mons">
+            {stage.map(node => (
+              <button
+                key={node.name}
+                className={`evo-node ${node.name === pokemon.name ? 'evo-current' : ''}`}
+                onClick={() => onNavigate(node.name)}
+                type="button"
+              >
+                <PokemonSprite name={node.name} className="evo-sprite" />
+                <span className="evo-name">{node.name}</span>
+                {node.method && <span className="evo-method">{node.method}</span>}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/docs/src/components/Header.tsx
+++ b/docs/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 const NAV_ITEMS = [
   { href: '/', label: 'Research Logs' },
   { href: '/guide', label: 'Game Guide' },
+  { href: '/pokedex', label: 'Pokedex' },
   { href: '/about', label: 'About' },
   { href: '/downloads', label: 'Downloads' },
 ];
@@ -32,7 +33,11 @@ export default function Header() {
           <Link
             key={item.href}
             to={item.href}
-            className={location.pathname === item.href ? 'active' : ''}
+            className={
+              location.pathname === item.href ||
+              (item.href === '/pokedex' && location.pathname.startsWith('/pokedex/'))
+                ? 'active' : ''
+            }
           >
             {item.label}
           </Link>

--- a/docs/src/components/LearnsetTable.tsx
+++ b/docs/src/components/LearnsetTable.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react';
+import TypeBadge from './TypeBadge';
+import type { PokedexEntry, MoveInfo } from '../lib/types';
+
+interface LearnsetTableProps {
+  pokemon: PokedexEntry;
+  moves: Record<string, MoveInfo>;
+}
+
+type Tab = 'levelUp' | 'tmhm' | 'tutor' | 'egg';
+
+function MoveRow({ name, info }: { name: string; info?: MoveInfo }) {
+  return (
+    <>
+      <td className="move-name">{name}</td>
+      <td>{info ? <TypeBadge type={info.type} /> : '—'}</td>
+      <td>{info?.category || '—'}</td>
+      <td>{info?.power || '—'}</td>
+      <td>{info?.accuracy || '—'}</td>
+      <td>{info?.pp || '—'}</td>
+    </>
+  );
+}
+
+export default function LearnsetTable({ pokemon, moves }: LearnsetTableProps) {
+  const [tab, setTab] = useState<Tab>('levelUp');
+
+  const tabs: { key: Tab; label: string; count: number }[] = [
+    { key: 'levelUp', label: 'Level Up', count: pokemon.learnset.levelUp.length },
+    { key: 'tmhm', label: 'TM/HM', count: pokemon.learnset.tmhm.length },
+    { key: 'tutor', label: 'Tutor', count: pokemon.learnset.tutor.length },
+    { key: 'egg', label: 'Egg Moves', count: pokemon.learnset.egg.length },
+  ];
+
+  return (
+    <div className="learnset-section">
+      <div className="learnset-tabs">
+        {tabs.map(t => (
+          <button
+            key={t.key}
+            className={`learnset-tab ${tab === t.key ? 'active' : ''}`}
+            onClick={() => setTab(t.key)}
+            type="button"
+          >
+            {t.label} ({t.count})
+          </button>
+        ))}
+      </div>
+
+      <div className="learnset-content">
+        {tab === 'levelUp' && (
+          <table className="learnset-table">
+            <thead>
+              <tr>
+                <th>Lv</th>
+                <th>Move</th>
+                <th>Type</th>
+                <th>Cat</th>
+                <th>Pow</th>
+                <th>Acc</th>
+                <th>PP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pokemon.learnset.levelUp.map((m, i) => (
+                <tr key={i}>
+                  <td className="move-level">{m.level}</td>
+                  <MoveRow name={m.move} info={moves[m.move]} />
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {tab === 'tmhm' && (
+          <table className="learnset-table">
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>Move</th>
+                <th>Type</th>
+                <th>Cat</th>
+                <th>Pow</th>
+                <th>Acc</th>
+                <th>PP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pokemon.learnset.tmhm.map((m, i) => (
+                <tr key={i}>
+                  <td className="move-level">{m.label}</td>
+                  <MoveRow name={m.move} info={moves[m.move]} />
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {tab === 'tutor' && (
+          <table className="learnset-table">
+            <thead>
+              <tr>
+                <th>Move</th>
+                <th>Type</th>
+                <th>Cat</th>
+                <th>Pow</th>
+                <th>Acc</th>
+                <th>PP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pokemon.learnset.tutor.map((name, i) => (
+                <tr key={i}>
+                  <MoveRow name={name} info={moves[name]} />
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {tab === 'egg' && (
+          <table className="learnset-table">
+            <thead>
+              <tr>
+                <th>Move</th>
+                <th>Type</th>
+                <th>Cat</th>
+                <th>Pow</th>
+                <th>Acc</th>
+                <th>PP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pokemon.learnset.egg.map((name, i) => (
+                <tr key={i}>
+                  <MoveRow name={name} info={moves[name]} />
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {tab !== 'levelUp' && tab !== 'tmhm' &&
+         ((tab === 'tutor' && pokemon.learnset.tutor.length === 0) ||
+          (tab === 'egg' && pokemon.learnset.egg.length === 0)) && (
+          <p className="learnset-empty">No moves in this category.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/src/components/PokedexCard.tsx
+++ b/docs/src/components/PokedexCard.tsx
@@ -1,0 +1,24 @@
+import PokemonSprite from './PokemonSprite';
+import TypeBadge from './TypeBadge';
+import type { PokedexEntry } from '../lib/types';
+
+interface PokedexCardProps {
+  pokemon: PokedexEntry;
+  onClick: () => void;
+}
+
+export default function PokedexCard({ pokemon, onClick }: PokedexCardProps) {
+  return (
+    <button className="pokedex-card" onClick={onClick} type="button">
+      <span className="pokedex-card-id">#{String(pokemon.id).padStart(3, '0')}</span>
+      <PokemonSprite name={pokemon.name} className="pokedex-card-sprite" />
+      <span className="pokedex-card-name">{pokemon.name}</span>
+      <div className="pokedex-card-types">
+        {pokemon.types.map(t => (
+          <TypeBadge key={t} type={t} />
+        ))}
+      </div>
+      <span className="pokedex-card-bst">BST {pokemon.bst}</span>
+    </button>
+  );
+}

--- a/docs/src/components/StatBar.tsx
+++ b/docs/src/components/StatBar.tsx
@@ -1,0 +1,32 @@
+interface StatBarProps {
+  label: string;
+  value: number;
+  max?: number;
+}
+
+const STAT_COLORS: Record<string, string> = {
+  HP: '#ff5252',
+  Atk: '#f08030',
+  Def: '#f8d030',
+  SpA: '#6890f0',
+  SpD: '#78c850',
+  Spe: '#f85888',
+};
+
+export default function StatBar({ label, value, max = 255 }: StatBarProps) {
+  const pct = Math.min(100, (value / max) * 100);
+  const color = STAT_COLORS[label] || '#4fc3f7';
+
+  return (
+    <div className="stat-bar-row">
+      <span className="stat-label">{label}</span>
+      <span className="stat-value">{value}</span>
+      <div className="stat-bar-track">
+        <div
+          className="stat-bar-fill"
+          style={{ width: `${pct}%`, backgroundColor: color }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/src/lib/types.ts
+++ b/docs/src/lib/types.ts
@@ -98,3 +98,86 @@ export interface ReleaseEntry {
   ipsName: string | null;
 }
 
+// ── Pokedex Types ──
+
+export interface PokemonStats {
+  hp: number;
+  atk: number;
+  def: number;
+  spa: number;
+  spd: number;
+  spe: number;
+}
+
+export interface LearnsetMove {
+  level: number;
+  move: string;
+}
+
+export interface TMHMMove {
+  label: string;
+  move: string;
+}
+
+export interface EvolutionTarget {
+  species: string;
+  method: string;
+}
+
+export interface EvolutionFrom {
+  from: string;
+  method: string;
+}
+
+export interface PokemonLocation {
+  map: string;
+  method: string;
+  minLevel: number;
+  maxLevel: number;
+  rate: number;
+}
+
+export interface MoveInfo {
+  type: string;
+  power: number;
+  accuracy: number;
+  pp: number;
+  category: string;
+}
+
+export interface PokedexEntry {
+  id: number;
+  name: string;
+  types: string[];
+  stats: PokemonStats;
+  bst: number;
+  abilities: string[];
+  category: string;
+  height: number;
+  weight: number;
+  description: string;
+  catchRate: number;
+  genderRatio: string;
+  eggGroups: string[];
+  growthRate: string;
+  evYield: PokemonStats;
+  heldItems: { common: string | null; rare: string | null };
+  learnset: {
+    levelUp: LearnsetMove[];
+    tmhm: TMHMMove[];
+    tutor: string[];
+    egg: string[];
+  };
+  evolution: {
+    evolvesFrom: EvolutionFrom | null;
+    evolvesTo: EvolutionTarget[];
+  };
+  locations: PokemonLocation[];
+}
+
+export interface PokedexData {
+  generatedAt: string;
+  pokemon: PokedexEntry[];
+  moves: Record<string, MoveInfo>;
+}
+

--- a/docs/src/main.tsx
+++ b/docs/src/main.tsx
@@ -6,6 +6,7 @@ import JournalPage from './pages/JournalPage';
 import GuidePage from './pages/GuidePage';
 import AboutPage from './pages/AboutPage';
 import DownloadsPage from './pages/DownloadsPage';
+import PokedexPage from './pages/PokedexPage';
 import './styles/globals.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
@@ -17,6 +18,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <Route path="/guide" element={<GuidePage />} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/downloads" element={<DownloadsPage />} />
+          <Route path="/pokedex" element={<PokedexPage />} />
+          <Route path="/pokedex/:name" element={<PokedexPage />} />
         </Routes>
       </Layout>
     </HashRouter>

--- a/docs/src/pages/PokedexPage.tsx
+++ b/docs/src/pages/PokedexPage.tsx
@@ -1,0 +1,268 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import PokedexCard from '../components/PokedexCard';
+import PokemonSprite from '../components/PokemonSprite';
+import TypeBadge from '../components/TypeBadge';
+import StatBar from '../components/StatBar';
+import EvolutionChain from '../components/EvolutionChain';
+import LearnsetTable from '../components/LearnsetTable';
+import PokeballSpinner from '../components/PokeballSpinner';
+import { rarityLabel } from '../lib/type-utils';
+import type { PokedexData, PokedexEntry } from '../lib/types';
+
+const ALL_TYPES = [
+  'Normal', 'Fire', 'Water', 'Grass', 'Electric', 'Ice',
+  'Fighting', 'Poison', 'Ground', 'Flying', 'Psychic', 'Bug',
+  'Rock', 'Ghost', 'Dragon', 'Dark', 'Steel',
+];
+
+type SortKey = 'id' | 'name' | 'bst';
+
+export default function PokedexPage() {
+  const { name } = useParams<{ name?: string }>();
+  const navigate = useNavigate();
+  const [data, setData] = useState<PokedexData | null>(null);
+  const [search, setSearch] = useState('');
+  const [typeFilter, setTypeFilter] = useState<string | null>(null);
+  const [sort, setSort] = useState<SortKey>('id');
+
+  useEffect(() => {
+    fetch(`${import.meta.env.BASE_URL}data/pokedex.json`)
+      .then(r => r.json())
+      .then(setData)
+      .catch(console.error);
+  }, []);
+
+  const filtered = useMemo(() => {
+    if (!data) return [];
+    let list = data.pokemon;
+
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter(p =>
+        p.name.toLowerCase().includes(q) ||
+        String(p.id).includes(q)
+      );
+    }
+
+    if (typeFilter) {
+      list = list.filter(p => p.types.includes(typeFilter));
+    }
+
+    if (sort === 'name') {
+      list = [...list].sort((a, b) => a.name.localeCompare(b.name));
+    } else if (sort === 'bst') {
+      list = [...list].sort((a, b) => b.bst - a.bst);
+    }
+    // default sort by id is already the natural order
+
+    return list;
+  }, [data, search, typeFilter, sort]);
+
+  if (!data) {
+    return (
+      <div className="page-loading">
+        <PokeballSpinner />
+        <p>Loading Pokedex data...</p>
+      </div>
+    );
+  }
+
+  // Detail view
+  if (name) {
+    const pokemon = data.pokemon.find(
+      p => p.name.toLowerCase().replace(/\s+/g, '-') === name.toLowerCase()
+    );
+
+    if (!pokemon) {
+      return (
+        <div className="pokedex-not-found">
+          <h2>Pokemon not found</h2>
+          <button onClick={() => navigate('/pokedex')} type="button" className="back-btn">
+            Back to Pokedex
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="pokedex-detail">
+        <button onClick={() => navigate('/pokedex')} type="button" className="back-btn">
+          &larr; Back to Pokedex
+        </button>
+
+        {/* Header */}
+        <div className="pokedex-detail-header">
+          <PokemonSprite name={pokemon.name} className="pokedex-detail-sprite" />
+          <div className="pokedex-detail-info">
+            <span className="pokedex-detail-id">#{String(pokemon.id).padStart(3, '0')}</span>
+            <h2 className="pokedex-detail-name">{pokemon.name}</h2>
+            <p className="pokedex-detail-category">The {pokemon.category} Pokemon</p>
+            <div className="pokedex-detail-types">
+              {pokemon.types.map(t => <TypeBadge key={t} type={t} />)}
+            </div>
+            {pokemon.description && (
+              <p className="pokedex-detail-desc">{pokemon.description}</p>
+            )}
+          </div>
+        </div>
+
+        {/* Stats + Info panels side by side */}
+        <div className="pokedex-panels">
+          {/* Base Stats */}
+          <div className="pokedex-panel">
+            <h3>Base Stats</h3>
+            <StatBar label="HP" value={pokemon.stats.hp} />
+            <StatBar label="Atk" value={pokemon.stats.atk} />
+            <StatBar label="Def" value={pokemon.stats.def} />
+            <StatBar label="SpA" value={pokemon.stats.spa} />
+            <StatBar label="SpD" value={pokemon.stats.spd} />
+            <StatBar label="Spe" value={pokemon.stats.spe} />
+            <div className="stat-bar-row stat-total">
+              <span className="stat-label">Total</span>
+              <span className="stat-value">{pokemon.bst}</span>
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="pokedex-panel">
+            <h3>Details</h3>
+            <table className="info-table">
+              <tbody>
+                <tr><td>Height</td><td>{pokemon.height} m</td></tr>
+                <tr><td>Weight</td><td>{pokemon.weight} kg</td></tr>
+                <tr><td>Abilities</td><td>{pokemon.abilities.join(', ') || '—'}</td></tr>
+                <tr><td>Catch Rate</td><td>{pokemon.catchRate}</td></tr>
+                <tr><td>Gender</td><td>{pokemon.genderRatio}</td></tr>
+                <tr><td>Egg Groups</td><td>{pokemon.eggGroups.join(', ')}</td></tr>
+                <tr><td>Growth Rate</td><td>{pokemon.growthRate}</td></tr>
+                <tr>
+                  <td>EV Yield</td>
+                  <td>
+                    {Object.entries(pokemon.evYield)
+                      .filter(([, v]) => v > 0)
+                      .map(([k, v]) => `${v} ${k.toUpperCase()}`)
+                      .join(', ') || 'None'}
+                  </td>
+                </tr>
+                {(pokemon.heldItems.common || pokemon.heldItems.rare) && (
+                  <tr>
+                    <td>Held Items</td>
+                    <td>
+                      {[pokemon.heldItems.common, pokemon.heldItems.rare]
+                        .filter(Boolean)
+                        .filter((v, i, a) => a.indexOf(v) === i)
+                        .join(', ')}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Evolution */}
+        <div className="pokedex-section">
+          <h3>Evolution</h3>
+          <EvolutionChain
+            pokemon={pokemon}
+            allPokemon={data.pokemon}
+            onNavigate={n => navigate(`/pokedex/${n.toLowerCase().replace(/\s+/g, '-')}`)}
+          />
+        </div>
+
+        {/* Learnset */}
+        <div className="pokedex-section">
+          <h3>Learnset</h3>
+          <LearnsetTable pokemon={pokemon} moves={data.moves} />
+        </div>
+
+        {/* Locations */}
+        {pokemon.locations.length > 0 && (
+          <div className="pokedex-section">
+            <h3>Locations</h3>
+            <table className="learnset-table">
+              <thead>
+                <tr>
+                  <th>Location</th>
+                  <th>Method</th>
+                  <th>Levels</th>
+                  <th>Rate</th>
+                  <th>Rarity</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pokemon.locations.map((loc, i) => (
+                  <tr key={i}>
+                    <td>{loc.map}</td>
+                    <td>{loc.method}</td>
+                    <td>{loc.minLevel === loc.maxLevel ? `Lv ${loc.minLevel}` : `Lv ${loc.minLevel}–${loc.maxLevel}`}</td>
+                    <td>{loc.rate}%</td>
+                    <td><span className={`rarity-tag rarity-${rarityLabel(loc.rate).toLowerCase().replace('-', '')}`}>{rarityLabel(loc.rate)}</span></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // List view
+  return (
+    <div className="pokedex-list-page">
+      <div className="pokedex-header">
+        <h2>Pokedex</h2>
+        <span className="pokedex-count">{filtered.length} / {data.pokemon.length} Pokemon</span>
+      </div>
+
+      <div className="pokedex-controls">
+        <input
+          type="text"
+          className="pokedex-search"
+          placeholder="Search by name or number..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+
+        <div className="pokedex-filters">
+          <select
+            className="pokedex-type-filter"
+            value={typeFilter || ''}
+            onChange={e => setTypeFilter(e.target.value || null)}
+          >
+            <option value="">All Types</option>
+            {ALL_TYPES.map(t => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+
+          <select
+            className="pokedex-sort"
+            value={sort}
+            onChange={e => setSort(e.target.value as SortKey)}
+          >
+            <option value="id">Sort by #</option>
+            <option value="name">Sort by Name</option>
+            <option value="bst">Sort by BST</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="pokedex-grid">
+        {filtered.map(p => (
+          <PokedexCard
+            key={p.id}
+            pokemon={p}
+            onClick={() => navigate(`/pokedex/${p.name.toLowerCase().replace(/\s+/g, '-')}`)}
+          />
+        ))}
+      </div>
+
+      {filtered.length === 0 && (
+        <p className="pokedex-empty">No Pokemon match your search.</p>
+      )}
+    </div>
+  );
+}

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -1918,3 +1918,500 @@ body::after {
 .release-github-link:hover {
   color: var(--text-accent);
 }
+
+/* ============================================================
+   POKEDEX PAGE
+   ============================================================ */
+
+/* ---- List View ---- */
+
+.pokedex-list-page { max-width: 1200px; margin: 0 auto; }
+
+.pokedex-header {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+.pokedex-header h2 {
+  font-family: var(--font-pixel);
+  font-size: 1.2rem;
+  color: var(--green-bright);
+  text-shadow: 0 0 10px var(--green-glow);
+}
+.pokedex-count {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.pokedex-controls {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.pokedex-search {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.6rem 1rem;
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+.pokedex-search:focus {
+  border-color: var(--green-bright);
+  box-shadow: 0 0 8px var(--green-glow);
+}
+.pokedex-search::placeholder { color: var(--text-muted); }
+
+.pokedex-filters {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.pokedex-type-filter,
+.pokedex-sort {
+  padding: 0.6rem 0.8rem;
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  cursor: pointer;
+  outline: none;
+}
+.pokedex-type-filter:focus,
+.pokedex-sort:focus {
+  border-color: var(--green-bright);
+}
+
+.pokedex-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.pokedex-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 1rem 0.5rem;
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-align: center;
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+}
+.pokedex-card:hover {
+  border-color: var(--green-bright);
+  box-shadow: 0 0 16px var(--green-glow), var(--shadow-card);
+  transform: translateY(-2px);
+}
+
+.pokedex-card-id {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+.pokedex-card-sprite {
+  width: 64px;
+  height: 64px;
+  image-rendering: pixelated;
+}
+.pokedex-card-name {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+.pokedex-card-types {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.pokedex-card-types .type-badge {
+  font-size: 0.6rem;
+  padding: 0.15rem 0.4rem;
+}
+.pokedex-card-bst {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+.pokedex-empty {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 3rem;
+  font-family: var(--font-mono);
+}
+
+/* ---- Detail View ---- */
+
+.pokedex-detail { max-width: 900px; margin: 0 auto; }
+
+.back-btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1.5rem;
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-md);
+  color: var(--text-accent);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.back-btn:hover {
+  border-color: var(--text-accent);
+  background: var(--lab-bg-lighter);
+}
+
+.pokedex-detail-header {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+  padding: 1.5rem;
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-lg);
+  margin-bottom: 1.5rem;
+}
+.pokedex-detail-sprite {
+  width: 96px;
+  height: 96px;
+  image-rendering: pixelated;
+  flex-shrink: 0;
+}
+.pokedex-detail-id {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+.pokedex-detail-name {
+  font-family: var(--font-pixel);
+  font-size: 1.1rem;
+  color: var(--green-bright);
+  margin: 0.25rem 0;
+}
+.pokedex-detail-category {
+  font-style: italic;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+.pokedex-detail-types {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+.pokedex-detail-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* ---- Stats & Info Panels ---- */
+
+.pokedex-panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.pokedex-panel {
+  padding: 1.25rem;
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-lg);
+}
+.pokedex-panel h3 {
+  font-family: var(--font-pixel);
+  font-size: 0.75rem;
+  color: var(--green-bright);
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.stat-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.stat-label {
+  width: 35px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-align: right;
+}
+.stat-value {
+  width: 30px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  text-align: right;
+}
+.stat-bar-track {
+  flex: 1;
+  height: 10px;
+  background: var(--lab-bg);
+  border-radius: 5px;
+  overflow: hidden;
+}
+.stat-bar-fill {
+  height: 100%;
+  border-radius: 5px;
+  transition: width 0.5s ease;
+}
+.stat-total {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--lab-panel-border);
+}
+.stat-total .stat-label { color: var(--text-primary); font-weight: 600; }
+.stat-total .stat-value { color: var(--green-bright); font-weight: 700; }
+
+.info-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.info-table td {
+  padding: 0.35rem 0;
+  font-size: 0.85rem;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+.info-table td:first-child {
+  color: var(--text-muted);
+  width: 40%;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+.info-table td:last-child { color: var(--text-primary); }
+
+/* ---- Sections ---- */
+
+.pokedex-section {
+  margin-bottom: 1.5rem;
+  padding: 1.25rem;
+  background: var(--lab-panel);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-lg);
+}
+.pokedex-section h3 {
+  font-family: var(--font-pixel);
+  font-size: 0.75rem;
+  color: var(--green-bright);
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.pokedex-not-found {
+  text-align: center;
+  padding: 4rem;
+  color: var(--text-muted);
+}
+
+/* ---- Evolution Chain ---- */
+
+.evo-chain {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.evo-stage {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.evo-stage-mons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.evo-arrow {
+  font-size: 1.5rem;
+  color: var(--text-muted);
+}
+.evo-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  background: var(--lab-bg);
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  color: var(--text-primary);
+  min-width: 90px;
+}
+.evo-node:hover {
+  border-color: var(--text-accent);
+  transform: translateY(-1px);
+}
+.evo-current {
+  border-color: var(--green-bright);
+  box-shadow: 0 0 8px var(--green-glow);
+}
+.evo-sprite {
+  width: 56px;
+  height: 56px;
+  image-rendering: pixelated;
+}
+.evo-name {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+.evo-method {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+.evo-none {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ---- Learnset ---- */
+
+.learnset-tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 1rem;
+  border-bottom: 1px solid var(--lab-panel-border);
+  padding-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+.learnset-tab {
+  padding: 0.4rem 0.8rem;
+  background: transparent;
+  border: 1px solid var(--lab-panel-border);
+  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.learnset-tab:hover { color: var(--text-primary); }
+.learnset-tab.active {
+  background: var(--lab-bg);
+  color: var(--green-bright);
+  border-color: var(--green-bright);
+  border-bottom-color: transparent;
+}
+
+.learnset-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+.learnset-table th {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--lab-panel-border);
+}
+.learnset-table td {
+  padding: 0.35rem 0.6rem;
+  border-bottom: 1px solid rgba(255,255,255,0.03);
+}
+.learnset-table tbody tr:hover {
+  background: rgba(0, 200, 83, 0.04);
+}
+.learnset-table .type-badge {
+  font-size: 0.6rem;
+  padding: 0.1rem 0.35rem;
+}
+
+.move-level {
+  font-family: var(--font-mono);
+  color: var(--text-accent);
+  font-weight: 600;
+  white-space: nowrap;
+}
+.move-name { font-weight: 500; }
+
+.learnset-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  padding: 1rem;
+}
+
+/* ---- Rarity Tags ---- */
+
+.rarity-tag {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+}
+.rarity-common    { background: rgba(0, 200, 83, 0.2); color: var(--green-bright); }
+.rarity-uncommon  { background: rgba(79, 195, 247, 0.2); color: var(--text-accent); }
+.rarity-rare      { background: rgba(179, 136, 255, 0.2); color: var(--purple-bright); }
+.rarity-ultrarare { background: rgba(255, 82, 82, 0.2); color: var(--red-bright); }
+
+/* ---- Responsive ---- */
+
+@media (max-width: 768px) {
+  .pokedex-grid {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.75rem;
+  }
+  .pokedex-detail-header {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .pokedex-panels {
+    grid-template-columns: 1fr;
+  }
+  .pokedex-controls {
+    flex-direction: column;
+  }
+  .pokedex-filters {
+    width: 100%;
+  }
+  .pokedex-type-filter,
+  .pokedex-sort {
+    flex: 1;
+  }
+  .evo-chain {
+    flex-direction: column;
+  }
+  .evo-arrow {
+    transform: rotate(90deg);
+  }
+  .learnset-table {
+    font-size: 0.75rem;
+  }
+  .learnset-table th,
+  .learnset-table td {
+    padding: 0.25rem 0.35rem;
+  }
+}


### PR DESCRIPTION
- New build script (build-pokedex.mjs) parses 12+ pokeemerald source files
  to extract species info, base stats, learnsets, evolution chains,
  wild encounters, and move data into pokedex.json
- Pokedex list view with search, type filter, and sort (by #/name/BST)
- Pokemon detail view showing base stats, abilities, type, catch rate,
  evolution chain, learnset (level-up/TM/HM/tutor/egg), and locations
- New components: PokedexCard, StatBar, EvolutionChain, LearnsetTable
- Responsive design matching existing retro CRT lab aesthetic

https://claude.ai/code/session_01RQVi4rXcxmWsuoBnjmQaxJ