### PR TITLE
Add cycle result indicator to journal cards

### DIFF
--- a/docs/build-scripts/build-journals.mjs
+++ b/docs/build-scripts/build-journals.mjs
@@ -62,6 +62,9 @@ function parseJournal(md, filename) {
   const summary = (sections['Summary'] || '').trim();
   const nextSteps = (sections['Next Steps'] || '').trim();
   const stats = parseStats(sections['Stats'] || '');
+  const validationStatus = parseValidationStatus(sections['Validation Warnings'] || '');
+  const isReverted = /\[REVERTED/.test(summary);
+  const cycleResult = computeCycleResult({ isReverted, validationStatus, buildResult, mode });
 
   // Plan output: first try the journal section, then fall back to git diff
   let planOutput = (sections['Plan Output'] || '').trim();
@@ -80,6 +83,7 @@ function parseJournal(md, filename) {
     summary,
     nextSteps,
     stats,
+    ...(cycleResult ? { cycleResult } : {}),
     ...(planOutput ? { planOutput } : {}),
   };
 }
@@ -135,6 +139,29 @@ function parseFilesList(text) {
     }
   }
   return files;
+}
+
+/**
+ * Parse validation warnings section for status.
+ */
+function parseValidationStatus(text) {
+  if (!text.trim()) return null;
+  const m = text.match(/\*\*Status\*\*:\s*(INCOMPLETE|UNSUBSTANTIATED)/i);
+  return m ? m[1].toUpperCase() : null;
+}
+
+/**
+ * Compute the overall cycle result from all available signals.
+ * Priority: reverted > validation warning > build result > planning mode.
+ */
+function computeCycleResult({ isReverted, validationStatus, buildResult, mode }) {
+  if (isReverted) return { status: 'reverted', label: 'REVERTED' };
+  if (validationStatus === 'INCOMPLETE') return { status: 'incomplete', label: 'INCOMPLETE' };
+  if (validationStatus === 'UNSUBSTANTIATED') return { status: 'unsubstantiated', label: 'UNSUBSTANTIATED' };
+  if (buildResult?.status === 'failure') return { status: 'build-failed', label: 'BUILD FAILED' };
+  if (buildResult?.status === 'success') return { status: 'build-passed', label: 'BUILD PASSED' };
+  if (mode === 'planning') return { status: 'plan-designed', label: 'PLAN DESIGNED' };
+  return null;
 }
 
 /**

--- a/docs/src/components/JournalCard.tsx
+++ b/docs/src/components/JournalCard.tsx
@@ -167,9 +167,6 @@ export default function JournalCard({ entry }: JournalCardProps) {
     ' \u00B7 ' +
     date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
 
-  const isSuccess = entry.buildResult?.status === 'success';
-  const isPlanning = entry.mode === 'planning';
-
   return (
     <div className={`journal-card mode-${entry.mode || 'research'}${expanded ? ' expanded' : ''}`}>
       <div className="card-header" onClick={() => setExpanded(!expanded)}>
@@ -181,17 +178,10 @@ export default function JournalCard({ entry }: JournalCardProps) {
 
       <div className="card-objective">{entry.objective || ''}</div>
 
-      {entry.buildResult && (
-        <div className={`build-indicator ${isSuccess ? 'success' : 'failure'}`}>
+      {entry.cycleResult && (
+        <div className={`build-indicator ${entry.cycleResult.status}`}>
           <span className="led"></span>
-          {isSuccess ? 'BUILD PASSED' : 'BUILD FAILED'}
-        </div>
-      )}
-
-      {isPlanning && !entry.buildResult && (
-        <div className="build-indicator plan">
-          <span className="led"></span>
-          PLAN DESIGNED
+          {entry.cycleResult.label}
         </div>
       )}
 

--- a/docs/src/lib/types.ts
+++ b/docs/src/lib/types.ts
@@ -10,6 +10,10 @@ export interface JournalEntry {
   buildResult?: {
     status: string;
   };
+  cycleResult?: {
+    status: 'reverted' | 'incomplete' | 'unsubstantiated' | 'build-failed' | 'build-passed' | 'plan-designed';
+    label: string;
+  };
   stats?: {
     tokensUsed?: number;
   };

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -36,6 +36,8 @@
   --purple-bright: #b388ff;
   --cyan-bright: #00e5ff;
   --cyan-glow: rgba(0, 229, 255, 0.15);
+  --orange-bright: #ffab40;
+  --orange-glow: rgba(255, 171, 64, 0.15);
 
   --font-pixel: 'Press Start 2P', monospace;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
@@ -427,16 +429,30 @@ body::after {
   font-weight: 500;
 }
 
-.build-indicator.success {
+.build-indicator.build-passed {
   background: var(--green-glow);
   color: var(--green-bright);
   border: 1px solid rgba(0, 230, 118, 0.2);
 }
 
-.build-indicator.failure {
+.build-indicator.build-failed {
   background: var(--red-glow);
   color: var(--red-bright);
   border: 1px solid rgba(255, 82, 82, 0.2);
+}
+
+.build-indicator.reverted {
+  background: var(--red-glow);
+  color: var(--red-bright);
+  border: 1px solid rgba(255, 82, 82, 0.3);
+  text-decoration: line-through;
+}
+
+.build-indicator.incomplete,
+.build-indicator.unsubstantiated {
+  background: var(--orange-glow);
+  color: var(--orange-bright);
+  border: 1px solid rgba(255, 171, 64, 0.2);
 }
 
 .build-indicator .led {
@@ -445,15 +461,18 @@ body::after {
   border-radius: 50%;
 }
 
-.build-indicator.success .led { background: var(--green-bright); box-shadow: 0 0 6px var(--green-bright); }
-.build-indicator.failure .led { background: var(--red-bright); box-shadow: 0 0 6px var(--red-bright); }
+.build-indicator.build-passed .led { background: var(--green-bright); box-shadow: 0 0 6px var(--green-bright); }
+.build-indicator.build-failed .led { background: var(--red-bright); box-shadow: 0 0 6px var(--red-bright); }
+.build-indicator.reverted .led { background: var(--red-bright); box-shadow: 0 0 6px var(--red-bright); }
+.build-indicator.incomplete .led,
+.build-indicator.unsubstantiated .led { background: var(--orange-bright); box-shadow: 0 0 6px var(--orange-bright); }
 
-.build-indicator.plan {
+.build-indicator.plan-designed {
   background: var(--cyan-glow);
   color: var(--cyan-bright);
   border: 1px solid rgba(0, 229, 255, 0.2);
 }
-.build-indicator.plan .led { background: var(--cyan-bright); box-shadow: 0 0 6px var(--cyan-bright); }
+.build-indicator.plan-designed .led { background: var(--cyan-bright); box-shadow: 0 0 6px var(--cyan-bright); }
 
 /* Card Body (expandable) */
 .card-body {


### PR DESCRIPTION
Cycle cards now show a comprehensive outcome indicator (not just build
pass/fail). Parses validation warnings and revert tags from journal
entries to display REVERTED, INCOMPLETE, UNSUBSTANTIATED, BUILD PASSED,
BUILD FAILED, or PLAN DESIGNED with distinct color-coded LED indicators.

https://claude.ai/code/session_01VEyrPHL7ZyGTNcWJAM2HMT