### PR TITLE
Fix unsubstantiated false negative for new-file cycles

### DIFF
--- a/src/git/committer.test.ts
+++ b/src/git/committer.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { buildDiffStats } from "./committer.js";
+
+const TRACKED_DIFF = ` pokeemerald/src/main.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)`;
+
+const TRACKED_DIFF_MULTI = ` pokeemerald/src/a.c | 4 ++--
+ pokeemerald/src/b.c | 6 ++++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)`;
+
+describe("buildDiffStats", () => {
+  it("parses a tracked-only diff with no untracked files", () => {
+    const stats = buildDiffStats(TRACKED_DIFF, []);
+    expect(stats.filesChanged).toBe(1);
+    expect(stats.insertions).toBe(2);
+    expect(stats.deletions).toBe(2);
+    expect(stats.summary).toContain("1 file changed");
+    expect(stats.summary).not.toContain("untracked");
+  });
+
+  it("parses a multi-file tracked diff", () => {
+    const stats = buildDiffStats(TRACKED_DIFF_MULTI, []);
+    expect(stats.filesChanged).toBe(2);
+    expect(stats.insertions).toBe(6);
+    expect(stats.deletions).toBe(4);
+  });
+
+  it("returns zero stats when both tracked and untracked are empty", () => {
+    const stats = buildDiffStats("", []);
+    expect(stats.filesChanged).toBe(0);
+    expect(stats.insertions).toBe(0);
+    expect(stats.deletions).toBe(0);
+    expect(stats.summary).toBe("No changes in pokeemerald/");
+  });
+
+  it("counts untracked files toward filesChanged when tracked diff is empty", () => {
+    // This is the cycle 202 false-negative case: a refactor cycle whose
+    // only output is brand-new scripts. git diff shows nothing, but the
+    // work is real.
+    const stats = buildDiffStats("", [
+      "pokeemerald/scripts/add_regional_form.cjs",
+      "pokeemerald/scripts/check_quest_flags.sh",
+      "pokeemerald/scripts/configs/corsola_hoenn.json",
+    ]);
+    expect(stats.filesChanged).toBe(3);
+    expect(stats.insertions).toBe(0);
+    expect(stats.deletions).toBe(0);
+    expect(stats.summary).toContain("3 untracked file(s)");
+    expect(stats.summary).toContain("add_regional_form.cjs");
+  });
+
+  it("sums tracked and untracked counts when both exist", () => {
+    const stats = buildDiffStats(TRACKED_DIFF_MULTI, [
+      "pokeemerald/data/new_table.h",
+    ]);
+    expect(stats.filesChanged).toBe(3); // 2 tracked + 1 untracked
+    expect(stats.insertions).toBe(6); // tracked-only
+    expect(stats.deletions).toBe(4); // tracked-only
+    expect(stats.summary).toContain("2 files changed");
+    expect(stats.summary).toContain("1 untracked file(s)");
+    expect(stats.summary).toContain("new_table.h");
+  });
+
+  it("truncates the untracked preview when more than 5 files exist", () => {
+    const untracked = Array.from({ length: 8 }, (_, i) => `pokeemerald/f${i}.c`);
+    const stats = buildDiffStats("", untracked);
+    expect(stats.filesChanged).toBe(8);
+    expect(stats.summary).toContain("8 untracked file(s)");
+    expect(stats.summary).toContain("+3 more");
+    expect(stats.summary).toContain("pokeemerald/f0.c");
+    expect(stats.summary).not.toContain("pokeemerald/f6.c");
+  });
+});

--- a/src/git/committer.ts
+++ b/src/git/committer.ts
@@ -213,24 +213,71 @@ export interface DiffStats {
   summary: string;
 }
 
-/** Get structured diff statistics for pokeemerald/ changes (staged + unstaged) */
+/**
+ * Count untracked files under pokeemerald/ that aren't covered by gitignore.
+ * `git diff --stat HEAD` is blind to never-added files, so cycles whose work
+ * is primarily *new* files (new scripts, new data, new sprite directories)
+ * would otherwise be flagged as unsubstantiated even though the work shipped.
+ *
+ * Returns a zero-length list on any failure so the caller can fall back to
+ * the tracked-only stats without losing them.
+ */
+async function listUntrackedPokeemeraldFiles(): Promise<string[]> {
+  try {
+    const output = await git.raw([
+      "ls-files",
+      "--others",
+      "--exclude-standard",
+      "--",
+      "pokeemerald/",
+    ]);
+    return output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Pure helper: combine the raw `git diff --stat` output and the list of
+ * untracked files into a `DiffStats`. Extracted so it can be unit-tested
+ * without touching the real git repo.
+ */
+export function buildDiffStats(rawDiffStat: string, untrackedFiles: string[]): DiffStats {
+  const stat = rawDiffStat.trim();
+  const lines = stat.split("\n");
+  const summaryLine = lines[lines.length - 1] ?? "";
+
+  const filesMatch = summaryLine.match(/(\d+)\s+files?\s+changed/);
+  const insertMatch = summaryLine.match(/(\d+)\s+insertions?\(\+\)/);
+  const deleteMatch = summaryLine.match(/(\d+)\s+deletions?\(-\)/);
+
+  const trackedFilesChanged = filesMatch ? parseInt(filesMatch[1], 10) : 0;
+  const insertions = insertMatch ? parseInt(insertMatch[1], 10) : 0;
+  const deletions = deleteMatch ? parseInt(deleteMatch[1], 10) : 0;
+
+  const filesChanged = trackedFilesChanged + untrackedFiles.length;
+
+  let summary = stat || "No changes in pokeemerald/";
+  if (untrackedFiles.length > 0) {
+    const preview = untrackedFiles.slice(0, 5).join(", ");
+    const more = untrackedFiles.length > 5 ? `, +${untrackedFiles.length - 5} more` : "";
+    summary += `\n ${untrackedFiles.length} untracked file(s) (newly created): ${preview}${more}`;
+  }
+
+  return { filesChanged, insertions, deletions, summary };
+}
+
+/** Get structured diff statistics for pokeemerald/ changes (staged + unstaged + untracked) */
 export async function getDiffStats(): Promise<DiffStats> {
   try {
-    // Include both staged and unstaged changes
+    // Tracked changes: staged + unstaged vs HEAD.
     const stat = await git.diff(["--stat", "HEAD", "--", "pokeemerald/"]);
-    const lines = stat.trim().split("\n");
-    const summaryLine = lines[lines.length - 1] ?? "";
-
-    const filesMatch = summaryLine.match(/(\d+)\s+files?\s+changed/);
-    const insertMatch = summaryLine.match(/(\d+)\s+insertions?\(\+\)/);
-    const deleteMatch = summaryLine.match(/(\d+)\s+deletions?\(-\)/);
-
-    return {
-      filesChanged: filesMatch ? parseInt(filesMatch[1], 10) : 0,
-      insertions: insertMatch ? parseInt(insertMatch[1], 10) : 0,
-      deletions: deleteMatch ? parseInt(deleteMatch[1], 10) : 0,
-      summary: stat.trim() || "No changes in pokeemerald/",
-    };
+    // Untracked files: not visible to `git diff`, but still real work.
+    const untrackedFiles = await listUntrackedPokeemeraldFiles();
+    return buildDiffStats(stat, untrackedFiles);
   } catch {
     return { filesChanged: 0, insertions: 0, deletions: 0, summary: "Could not compute diff stats" };
   }


### PR DESCRIPTION
getDiffStats() relied solely on `git diff --stat HEAD -- pokeemerald/`,
which is blind to untracked files. Refactor cycles whose work is brand
new files (e.g. cycle 202's add_regional_form.cjs pipeline) were flagged
as UNSUBSTANTIATED even though the work shipped.

Now also call `git ls-files --others --exclude-standard -- pokeemerald/`
and add the untracked count to filesChanged. Extracted the parsing math
into a pure buildDiffStats() helper so it can be unit-tested without git.

https://claude.ai/code/session_01YJE5zFKHgZPJsa5MsUtAKP