### PR TITLE
Add boss fights section to docs game guide

### DIFF
--- a/docs/build-scripts/build-game-guide.mjs
+++ b/docs/build-scripts/build-game-guide.mjs
@@ -387,6 +387,61 @@ function assembleChampion(trainers, parties) {
   };
 }
 
+// ── Boss Fights ──
+//
+// "Boss fights" covers story battles that aren't gym leaders, the Elite Four,
+// the Champion, or your rival: Team Magma/Aqua admins and their leaders, the
+// Wally fights (Mauville + Victory Road escalation), and the Mossdeep tag
+// battle with Steven. These are some of the most memorable fights in the
+// game and deserve first-class coverage in the guide.
+const BOSS_DEFINITIONS = [
+  { key: 'wally_mauville',          trainerId: 'TRAINER_WALLY_MAUVILLE',          name: 'Wally',   faction: 'Wally',    location: 'Mauville City' },
+  { key: 'maxie_mt_chimney',        trainerId: 'TRAINER_MAXIE_MT_CHIMNEY',        name: 'Maxie',   faction: 'Magma',    location: 'Mt. Chimney' },
+  { key: 'tabitha_mt_chimney',      trainerId: 'TRAINER_TABITHA_MT_CHIMNEY',      name: 'Tabitha', faction: 'Magma',    location: 'Mt. Chimney' },
+  { key: 'shelly_weather_institute',trainerId: 'TRAINER_SHELLY_WEATHER_INSTITUTE',name: 'Shelly',  faction: 'Aqua',     location: 'Weather Institute' },
+  { key: 'matt',                    trainerId: 'TRAINER_MATT',                    name: 'Matt',    faction: 'Aqua',     location: 'Mt. Pyre' },
+  { key: 'matthew',                 trainerId: 'TRAINER_MATTHEW',                 name: 'Matthew', faction: 'Aqua',     location: 'Magma Hideout' },
+  { key: 'tabitha_magma_hideout',   trainerId: 'TRAINER_TABITHA_MAGMA_HIDEOUT',   name: 'Tabitha', faction: 'Magma',    location: 'Magma Hideout' },
+  { key: 'maxie_magma_hideout',     trainerId: 'TRAINER_MAXIE_MAGMA_HIDEOUT',     name: 'Maxie',   faction: 'Magma',    location: 'Magma Hideout' },
+  { key: 'shelly_seafloor_cavern',  trainerId: 'TRAINER_SHELLY_SEAFLOOR_CAVERN',  name: 'Shelly',  faction: 'Aqua',     location: 'Seafloor Cavern' },
+  { key: 'archie',                  trainerId: 'TRAINER_ARCHIE',                  name: 'Archie',  faction: 'Aqua',     location: 'Seafloor Cavern' },
+  { key: 'tabitha_mossdeep',        trainerId: 'TRAINER_TABITHA_MOSSDEEP',        name: 'Tabitha', faction: 'Magma',    location: 'Mossdeep City' },
+  { key: 'maxie_mossdeep',          trainerId: 'TRAINER_MAXIE_MOSSDEEP',          name: 'Maxie',   faction: 'Magma',    location: 'Mossdeep City' },
+  { key: 'steven_multi',            trainerId: 'TRAINER_STEVEN',                  name: 'Steven',  faction: 'Champion', location: 'Mossdeep City' },
+  { key: 'wally_vr_1',              trainerId: 'TRAINER_WALLY_VR_1',              name: 'Wally',   faction: 'Wally',    location: 'Victory Road (Tier 1)' },
+  { key: 'wally_vr_2',              trainerId: 'TRAINER_WALLY_VR_2',              name: 'Wally',   faction: 'Wally',    location: 'Victory Road (Tier 2)' },
+  { key: 'wally_vr_3',              trainerId: 'TRAINER_WALLY_VR_3',              name: 'Wally',   faction: 'Wally',    location: 'Victory Road (Tier 3)' },
+  { key: 'wally_vr_4',              trainerId: 'TRAINER_WALLY_VR_4',              name: 'Wally',   faction: 'Wally',    location: 'Victory Road (Tier 4)' },
+  { key: 'wally_vr_5',              trainerId: 'TRAINER_WALLY_VR_5',              name: 'Wally',   faction: 'Wally',    location: 'Victory Road (Tier 5)' },
+];
+
+function assembleBossFights(trainers, parties) {
+  const byId = new Map(trainers.map(t => [t.id, t]));
+  const fights = [];
+
+  for (const def of BOSS_DEFINITIONS) {
+    const trainer = byId.get(def.trainerId);
+    if (!trainer) {
+      console.warn(`  ! Boss trainer not found: ${def.trainerId}`);
+      continue;
+    }
+    const party = parties.get(trainer.partyRef) || [];
+    if (party.length === 0) {
+      console.warn(`  ! Boss party empty: ${def.trainerId} -> ${trainer.partyRef}`);
+    }
+    fights.push({
+      key: def.key,
+      name: def.name,
+      faction: def.faction,
+      location: def.location,
+      doubleBattle: trainer.doubleBattle,
+      party,
+    });
+  }
+
+  return fights;
+}
+
 function assembleRivals(trainers, parties, starters) {
   // Map vanilla starter ID suffixes → the actual new player starter for that matchup.
   // Trainer IDs like TRAINER_BRENDAN_ROUTE_103_MUDKIP were named for the vanilla rival's
@@ -462,6 +517,7 @@ async function main() {
   const eliteFour = assembleEliteFour(trainers, parties);
   const champion = assembleChampion(trainers, parties);
   const rivals = assembleRivals(trainers, parties, starters);
+  const bossFights = assembleBossFights(trainers, parties);
 
   const guide = {
     generatedAt: new Date().toISOString(),
@@ -471,6 +527,7 @@ async function main() {
     eliteFour,
     champion,
     rivals,
+    bossFights,
   };
 
   await mkdir(OUTPUT_DIR, { recursive: true });
@@ -480,6 +537,7 @@ async function main() {
   console.log(`  Elite Four: ${eliteFour.length}`);
   console.log(`  Champion: ${champion ? champion.name : 'not found'}`);
   console.log(`  Rival battles: ${rivals.length}`);
+  console.log(`  Boss fights: ${bossFights.length}`);
 }
 
 main().catch(err => {

--- a/docs/src/lib/game-progression.ts
+++ b/docs/src/lib/game-progression.ts
@@ -4,7 +4,7 @@
  */
 
 export interface ProgressionStep {
-  type: 'starter' | 'route' | 'gym' | 'rival' | 'elite-four' | 'champion' | 'landmark' | 'chapter';
+  type: 'starter' | 'route' | 'gym' | 'rival' | 'elite-four' | 'champion' | 'landmark' | 'chapter' | 'boss';
   label: string;
   /** Matches key in GuideData.routes (e.g. "Route 101", "Petalburg Woods") */
   routeKeys?: string[];
@@ -12,6 +12,8 @@ export interface ProgressionStep {
   gymNumber?: number;
   /** Substring match against rival battle location */
   rivalLocation?: string;
+  /** For type === 'boss': one or more BossBattle.key values to render as a group */
+  bossKeys?: string[];
   /** Flavor text for landmarks / chapters */
   description?: string;
 }
@@ -51,6 +53,7 @@ export const GAME_PROGRESSION: ProgressionStep[] = [
   { type: 'rival', label: 'Rival Battle \u2014 Route 110', rivalLocation: 'Route 110' },
   { type: 'landmark', label: 'Mauville City', description: 'The crossroads of Hoenn, home to the Game Corner and Bike Shop.' },
   { type: 'gym', label: 'Gym 3: Wattson', gymNumber: 3 },
+  { type: 'boss', label: 'Boss Fight \u2014 Wally (Mauville City)', bossKeys: ['wally_mauville'] },
   { type: 'route', label: 'New Mauville', routeKeys: ['New Mauville Entrance', 'New Mauville Inside'] },
 
   // ── Chapter 5: The Road to Lavaridge ──
@@ -63,6 +66,7 @@ export const GAME_PROGRESSION: ProgressionStep[] = [
   { type: 'landmark', label: 'Fallarbor Town', description: 'A quiet town near the foot of Mt. Chimney.' },
   { type: 'route', label: 'Route 114', routeKeys: ['Route 114'] },
   { type: 'route', label: 'Meteor Falls', routeKeys: ['Meteor Falls 1f 1r', 'Meteor Falls 1f 2r'] },
+  { type: 'boss', label: 'Boss Fights \u2014 Tabitha & Maxie (Mt. Chimney)', bossKeys: ['tabitha_mt_chimney', 'maxie_mt_chimney'] },
   { type: 'route', label: 'Jagged Pass', routeKeys: ['Jagged Pass'] },
   { type: 'landmark', label: 'Lavaridge Town', description: 'A town famous for its hot springs, nestled at the base of Mt. Chimney.' },
   { type: 'gym', label: 'Gym 4: Flannery', gymNumber: 4 },
@@ -78,6 +82,7 @@ export const GAME_PROGRESSION: ProgressionStep[] = [
   { type: 'route', label: 'Route 118', routeKeys: ['Route 118'] },
   { type: 'route', label: 'Route 119', routeKeys: ['Route 119'] },
   { type: 'rival', label: 'Rival Battle \u2014 Route 119', rivalLocation: 'Route 119' },
+  { type: 'boss', label: 'Boss Fight \u2014 Shelly (Weather Institute)', bossKeys: ['shelly_weather_institute'] },
   { type: 'landmark', label: 'Fortree City', description: 'A city of treehouses deep in the forest.' },
   { type: 'gym', label: 'Gym 6: Winona', gymNumber: 6 },
   { type: 'route', label: 'Route 120', routeKeys: ['Route 120'] },
@@ -90,8 +95,10 @@ export const GAME_PROGRESSION: ProgressionStep[] = [
   { type: 'rival', label: 'Rival Battle \u2014 Lilycove', rivalLocation: 'Lilycove' },
   { type: 'route', label: 'Route 122', routeKeys: ['Route 122'] },
   { type: 'route', label: 'Mt. Pyre', routeKeys: ['Mt Pyre 1f', 'Mt Pyre 2f', 'Mt Pyre 3f', 'Mt Pyre 4f', 'Mt Pyre 5f', 'Mt Pyre 6f', 'Mt Pyre Exterior', 'Mt Pyre Summit'] },
+  { type: 'boss', label: 'Boss Fight \u2014 Matt (Mt. Pyre Summit)', bossKeys: ['matt'] },
   { type: 'route', label: 'Route 123', routeKeys: ['Route 123'] },
   { type: 'route', label: 'Magma Hideout', routeKeys: ['Magma Hideout 1f', 'Magma Hideout 2f 1r', 'Magma Hideout 2f 2r', 'Magma Hideout 2f 3r', 'Magma Hideout 3f 1r', 'Magma Hideout 3f 2r', 'Magma Hideout 3f 3r', 'Magma Hideout 4f'] },
+  { type: 'boss', label: 'Boss Fights \u2014 Matthew, Tabitha & Maxie (Magma Hideout)', bossKeys: ['matthew', 'tabitha_magma_hideout', 'maxie_magma_hideout'] },
 
   // ── Chapter 9: The Deep Sea ──
   { type: 'chapter', label: 'Chapter 9: The Deep Sea', description: 'Dive beneath the ocean and earn the Mind Badge on Mossdeep Island.' },
@@ -99,8 +106,10 @@ export const GAME_PROGRESSION: ProgressionStep[] = [
   { type: 'route', label: 'Shoal Cave', routeKeys: ['Shoal Cave Low Tide Entrance Room', 'Shoal Cave Low Tide Ice Room', 'Shoal Cave Low Tide Inner Room', 'Shoal Cave Low Tide Lower Room', 'Shoal Cave Low Tide Stairs Room'] },
   { type: 'landmark', label: 'Mossdeep City', description: 'Home to the Space Center and the 7th Gym.' },
   { type: 'gym', label: 'Gym 7: Tate & Liza', gymNumber: 7 },
+  { type: 'boss', label: 'Boss Fights \u2014 Tabitha, Maxie & Steven (Mossdeep City)', bossKeys: ['tabitha_mossdeep', 'maxie_mossdeep', 'steven_multi'] },
   { type: 'route', label: 'Route 127', routeKeys: ['Route 127'] },
   { type: 'route', label: 'Seafloor Cavern', routeKeys: ['Seafloor Cavern Entrance', 'Seafloor Cavern Room1', 'Seafloor Cavern Room2', 'Seafloor Cavern Room3', 'Seafloor Cavern Room4', 'Seafloor Cavern Room5', 'Seafloor Cavern Room6', 'Seafloor Cavern Room7', 'Seafloor Cavern Room8'] },
+  { type: 'boss', label: 'Boss Fights \u2014 Shelly & Archie (Seafloor Cavern)', bossKeys: ['shelly_seafloor_cavern', 'archie'] },
 
   // ── Chapter 10: The Final Gym ──
   { type: 'chapter', label: 'Chapter 10: The Final Gym', description: 'Calm Groudon and Kyogre, then earn your 8th badge.' },
@@ -114,6 +123,7 @@ export const GAME_PROGRESSION: ProgressionStep[] = [
   { type: 'route', label: 'Sea Routes 129\u2013134', routeKeys: ['Route 129', 'Route 130', 'Route 131', 'Route 132', 'Route 133', 'Route 134'] },
   { type: 'landmark', label: 'Ever Grande City', description: 'The gateway to the Pok\u00e9mon League.' },
   { type: 'route', label: 'Victory Road', routeKeys: ['Victory Road 1f', 'Victory Road B1f', 'Victory Road B2f'] },
+  { type: 'boss', label: 'Boss Fight \u2014 Wally Rematch Tiers (Victory Road)', bossKeys: ['wally_vr_1', 'wally_vr_2', 'wally_vr_3', 'wally_vr_4', 'wally_vr_5'] },
   { type: 'elite-four', label: 'Elite Four' },
   { type: 'champion', label: 'Champion' },
 

--- a/docs/src/lib/types.ts
+++ b/docs/src/lib/types.ts
@@ -60,6 +60,19 @@ export interface RivalBattle {
   party: PartyMember[];
 }
 
+export interface BossBattle {
+  /** Stable identifier (e.g. 'maxie_mt_chimney') — matched by ProgressionStep.bossKey */
+  key: string;
+  /** Display name of the trainer (e.g. 'Maxie') */
+  name: string;
+  /** Faction label used for the type badge and card title */
+  faction: 'Magma' | 'Aqua' | 'Wally' | 'Champion';
+  /** Human-readable location shown as the card subtitle */
+  location: string;
+  doubleBattle?: boolean;
+  party: PartyMember[];
+}
+
 export interface EncounterEntry {
   species: string;
   minLevel: number;
@@ -89,6 +102,7 @@ export interface GuideData {
   eliteFour: EliteFourMember[];
   champion: Champion | null;
   rivals: RivalBattle[];
+  bossFights: BossBattle[];
   routes: Record<string, RouteData>;
 }
 

--- a/docs/src/pages/GuidePage.tsx
+++ b/docs/src/pages/GuidePage.tsx
@@ -72,11 +72,20 @@ function computeStats(data: GuideData) {
       if (mon.level > maxLevel) maxLevel = mon.level;
     }
   }
+  for (const boss of data.bossFights || []) {
+    for (const mon of boss.party) {
+      if (mon.level > maxLevel) maxLevel = mon.level;
+    }
+  }
 
   return {
     totalRoutes: Object.keys(data.routes).length,
     totalSpecies: allSpecies.size,
-    trainers: data.gymLeaders.length + data.eliteFour.length + (data.champion ? 1 : 0),
+    trainers:
+      data.gymLeaders.length +
+      data.eliteFour.length +
+      (data.champion ? 1 : 0) +
+      (data.bossFights?.length || 0),
     levelRange: `Lv ${minLevel}\u2013${maxLevel}`,
   };
 }
@@ -168,6 +177,29 @@ function StepRenderer({
       );
     }
 
+    case 'boss': {
+      if (!step.bossKeys || step.bossKeys.length === 0) return null;
+      const fights = (data.bossFights || []).filter(b => step.bossKeys!.includes(b.key));
+      if (fights.length === 0) return null;
+      // Preserve the author's ordering from bossKeys (not the JSON order).
+      const ordered = step.bossKeys
+        .map(k => fights.find(f => f.key === k))
+        .filter((b): b is NonNullable<typeof b> => !!b);
+      return (
+        <>
+          {ordered.map(boss => (
+            <TrainerCard
+              key={boss.key}
+              title={`${boss.faction === 'Wally' ? 'Wally' : boss.faction + ' ' + boss.name} \u2014 ${boss.location}`}
+              subtitle={boss.doubleBattle ? 'Double Battle' : ''}
+              typeBadge={boss.faction}
+              party={boss.party}
+            />
+          ))}
+        </>
+      );
+    }
+
     case 'rival': {
       const battles = data.rivals.filter(r => {
         if (!step.rivalLocation) return false;
@@ -247,6 +279,7 @@ function StepRenderer({
 function stepTypeClass(type: ProgressionStep['type']): string {
   switch (type) {
     case 'gym': return 'step-gym';
+    case 'boss': return 'step-boss';
     case 'rival': return 'step-rival';
     case 'route': return 'step-route';
     case 'elite-four': return 'step-elite';

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -1105,6 +1105,9 @@ body::after {
 .type-dragon     { background: #7038f8; }
 .type-champion   { background: linear-gradient(135deg, #ffd740, #ff6d00); color: #333; }
 .type-rival      { background: linear-gradient(135deg, var(--pokeball-red), var(--pokeball-red-dark)); }
+.type-magma      { background: linear-gradient(135deg, #e25822, #7a1f0f); }
+.type-aqua       { background: linear-gradient(135deg, #2c7fb8, #0b2d4a); }
+.type-wally      { background: linear-gradient(135deg, #7a57c4, #3b1f68); }
 .type-steel      { background: #b8b8d0; color: #333; }
 .type-grass      { background: #78c850; }
 .type-poison     { background: #a040a0; }
@@ -1531,6 +1534,10 @@ body::after {
 
 .progression-step.step-rival {
   border-left-color: var(--red-bright);
+}
+
+.progression-step.step-boss {
+  border-left-color: #e25822;
 }
 
 .progression-step.step-route {


### PR DESCRIPTION
Surfaces the story battles that aren't gym leaders, Elite Four, Champion,
or rivals — Team Magma (Maxie, Tabitha), Team Aqua (Archie, Matt, Matthew,
Shelly), Wally (Mauville + 5 Victory Road tiers), and the Mossdeep tag
battle with Steven — so players can preview the 18 major boss encounters
inline with the existing progression timeline.

- build-game-guide.mjs: new assembleBossFights() emits bossFights[] in
  game-guide.json from the existing parseTrainers/parseTrainerParties maps
- types.ts: adds BossBattle interface; extends GuideData
- game-progression.ts: new 'boss' step type and bossKeys field; inserts
  boss beats at their chronological locations across chapters 4-11
- GuidePage.tsx: renders boss steps via the existing TrainerCard, counts
  bosses in the Key Trainers stat, adds step-boss timeline color
- globals.css: new .type-magma / .type-aqua / .type-wally badges and
  .step-boss timeline accent