### PR TITLE
Decouple sprite iteration from main cycle pipeline

### DIFF
--- a/src/agent/prompt-sections.ts
+++ b/src/agent/prompt-sections.ts
@@ -212,6 +212,7 @@ You have access to a **Sprite Designer** agent that creates and iterates on regi
 - The species being iterated
 - Specific community feedback quotes from the sprite-feedback issue
 - What changes to prioritize
+- **Set \`isSpriteIteration: true\`** so the runner runs the iteration in parallel with implementation (faster cycles, no blocking)
 
 **When you set a brief**: Your \`implementationPlan\` should focus on species registration (constants, tables, stats) — the Sprite Designer handles the sprite files.
 

--- a/src/cycle/planner.ts
+++ b/src/cycle/planner.ts
@@ -29,6 +29,8 @@ export interface CyclePlan {
   creativeInvestment?: string;
   /** Optional brief for the Sprite Designer agent. When set, Phase 1.75 spawns a specialist to create or iterate on regional form sprites. For fresh sprites: describe the species, target typing, and aesthetic direction. For iterations: include community feedback quotes from the sprite-feedback issue. */
   spriteDesignBrief?: string;
+  /** When true, indicates this sprite brief is an iteration on existing sprites (community feedback rework) rather than fresh sprite creation. Iterations run in parallel with the implementation phase instead of blocking it. */
+  isSpriteIteration?: boolean;
   issueActions: IssueAction[];
   helpRequests: HelpRequest[];
 }
@@ -69,6 +71,10 @@ export const CYCLE_PLAN_SCHEMA: Record<string, unknown> = {
     spriteDesignBrief: {
       type: "string",
       description: "Optional brief for the Sprite Designer agent. Set this when the cycle involves creating or iterating on regional form sprites. The Sprite Designer has access to Pillow, the sprite fetcher MCP tool, and memory of accumulated sprite techniques. For fresh sprites: describe the base species, target typing, and aesthetic direction (e.g., 'Create Hoenn Growlithe sprites: Electric/Fire. Base: growlithe. Electric-gold palette with lightning glyph accents.'). For iterations: include community feedback quotes from the sprite-feedback GitHub issue (e.g., 'Iterate on Arcanine Hoenn sprites based on feedback: gold is too close to original orange, needs more blue-electric accents on the mane.').",
+    },
+    isSpriteIteration: {
+      type: "boolean",
+      description: "Set to true when spriteDesignBrief is an iteration on existing sprites based on community feedback (not a fresh sprite creation). Iteration work runs in parallel with the implementation phase so it doesn't block or slow down the main cycle. Only relevant when spriteDesignBrief is set.",
     },
     issueActions: {
       type: "array",
@@ -145,6 +151,7 @@ export function parsePlanResult(result: ClaudeCodeResult): CyclePlan {
     gameplayDesignBrief?: string;
     engineeringInvestment?: string;
     spriteDesignBrief?: string;
+    isSpriteIteration?: boolean;
     issueActions?: IssueAction[];
     helpRequests?: HelpRequest[];
   }
@@ -222,6 +229,7 @@ export function parsePlanResult(result: ClaudeCodeResult): CyclePlan {
       gameplayDesignBrief: parsed.gameplayDesignBrief || undefined,
       engineeringInvestment: parsed.engineeringInvestment || undefined,
       spriteDesignBrief: parsed.spriteDesignBrief || undefined,
+      isSpriteIteration: parsed.isSpriteIteration ?? false,
       issueActions,
       helpRequests,
     };

--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -669,6 +669,9 @@ export async function runCycle(): Promise<void> {
   const sessionStartSha = await getHeadSha();
   log.info(`Session start SHA: ${sessionStartSha}`);
 
+  // Hoisted so the catch block can suppress unhandled rejections on crash
+  let spriteIterationPromise: Promise<SpriteDesignResult> | null = null;
+
   try {
     // ── Phase 1: Planning (separate agent context) ──
     const { memory, recentJournals, plan } = await runPlanningPhase(cycleNumber, log);
@@ -718,27 +721,41 @@ export async function runCycle(): Promise<void> {
     let spriteDesignTokenUsage: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
 
     if (activePlan.spriteDesignBrief) {
-      log.info("Phase 1.75: Sprite Design...");
-      try {
-        spriteResult = await runSpriteDesigner(
+      if (activePlan.isSpriteIteration) {
+        // ITERATION: Launch sprite designer in parallel — don't block implementation.
+        // The species is already registered; iteration only overwrites existing PNGs/PALs.
+        log.info("Phase 1.75: Sprite Iteration (launching in parallel with implementation)...");
+        spriteIterationPromise = runSpriteDesigner(
           activePlan.objective,
           activePlan.spriteDesignBrief,
           activePlan.implementationPlan,
         );
-        activePlan = {
-          ...activePlan,
-          implementationPlan: `${activePlan.implementationPlan}\n\n## Sprite Design Report (from Sprite Designer)\n\n${spriteResult.spriteReport}\n\nFiles created/modified:\n${spriteResult.filesCreated.map(f => `- ${f}`).join("\n")}`,
-        };
-        spriteDesignTokenUsage = spriteResult.tokenUsage;
-        log.info(`  Sprite design complete: ${spriteResult.toolCallCount} tool calls, ${spriteResult.filesCreated.length} files`);
-      } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        log.warn(`  Sprite Designer failed, proceeding with placeholder approach: ${errMsg}`);
-        // Fall through — implementation agent can copy sprites from base species as fallback
+        // Don't await — continues to Phase 2 immediately
+      } else {
+        // FRESH: Run sequentially — implementation needs the sprite report
+        log.info("Phase 1.75: Sprite Design (fresh)...");
+        try {
+          spriteResult = await runSpriteDesigner(
+            activePlan.objective,
+            activePlan.spriteDesignBrief,
+            activePlan.implementationPlan,
+          );
+          activePlan = {
+            ...activePlan,
+            implementationPlan: `${activePlan.implementationPlan}\n\n## Sprite Design Report (from Sprite Designer)\n\n${spriteResult.spriteReport}\n\nFiles created/modified:\n${spriteResult.filesCreated.map(f => `- ${f}`).join("\n")}`,
+          };
+          spriteDesignTokenUsage = spriteResult.tokenUsage;
+          log.info(`  Sprite design complete: ${spriteResult.toolCallCount} tool calls, ${spriteResult.filesCreated.length} files`);
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          log.warn(`  Sprite Designer failed, proceeding with placeholder approach: ${errMsg}`);
+          // Fall through — implementation agent can copy sprites from base species as fallback
+        }
       }
     }
 
     // ── Phase 2: Implementation (separate agent context) ──
+    // (runs concurrently with sprite iteration if one was launched above)
     let implResult = await runImplementationPhase(
       cycleNumber,
       activePlan,
@@ -746,6 +763,20 @@ export async function runCycle(): Promise<void> {
       recentJournals,
       log,
     );
+
+    // ── Collect parallel sprite iteration result (if launched) ──
+    if (spriteIterationPromise) {
+      log.info("  Collecting parallel sprite iteration result...");
+      try {
+        spriteResult = await spriteIterationPromise;
+        spriteDesignTokenUsage = spriteResult.tokenUsage;
+        log.info(`  Sprite iteration complete: ${spriteResult.toolCallCount} tool calls, ${spriteResult.filesCreated.length} files`);
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log.warn(`  Sprite iteration (parallel) failed, continuing without sprite changes: ${errMsg}`);
+        // spriteResult stays null — Phase 3.6 will be skipped, main cycle unaffected
+      }
+    }
 
     // ── Phase 3: Build verification + auto-fix loop ──
     let {
@@ -1123,6 +1154,9 @@ export async function runCycle(): Promise<void> {
     }
     log.info("═══════════════════════════════════════════════════");
   } catch (err) {
+    // Suppress unhandled rejection from any in-flight sprite iteration
+    spriteIterationPromise?.catch(() => {});
+
     log.error(`Cycle failed with error: ${err instanceof Error ? err.message : String(err)}`);
     if (err instanceof Error && err.stack) {
       log.error(err.stack);


### PR DESCRIPTION
Sprite iterations (community feedback rework) now run in parallel with
Phase 2 (Implementation) instead of blocking it. Fresh sprite creation
remains sequential since the implementation agent needs the sprite report.

- Add `isSpriteIteration` boolean to CyclePlan interface and JSON schema
- Branch Phase 1.75 in runner: iterations launch without awaiting, fresh
  sprites await as before
- Collect parallel sprite result after Phase 2 completes, before build
- Hoist promise variable for unhandled-rejection cleanup on cycle crash
- Update planner guidance to instruct setting the flag for iterations

https://claude.ai/code/session_0151RL4tmTgv77ZKPFHLvZZH