### PR TITLE
Fix sprite feedback GitHub issue: broken images, metadata leak, noisy report

### DIFF
--- a/src/cycle/runner.ts
+++ b/src/cycle/runner.ts
@@ -33,7 +33,7 @@ import {
 import { validateCycle, getUnsubstantiatedIssueCompletions } from "../reflection/validator.js";
 import type { ValidationResult, ValidationStatus } from "../reflection/validator.js";
 import { fetchNewCommunityIssues, formatIssuesForPrompt, executeIssueActions, createHelpRequest, readIssueBacklog, updateIssueBacklog, addIssueToBacklog, getStaleBacklogIssues, postIssueClosingComment, postIssuePartialDeliveryComment, formatSpriteFeedbackForPlanner, createSpriteFeedbackIssue, postSpriteIterationUpdate } from "../github/issues.js";
-import { closeIssue, addLabelsToIssue, setDecisionLabel, commentOnIssue, AGENT_LABELS } from "../github/client.js";
+import { closeIssue, addLabelsToIssue, setDecisionLabel, commentOnIssue, AGENT_LABELS, getRepoInfo } from "../github/client.js";
 import { cycleLogger, logger } from "../utils/logger.js";
 import { PROJECT_ROOT, ARTIFACTS_DIR, MEMORY_DIR } from "../utils/paths.js";
 import { createCycleRelease } from "../release/release.js";
@@ -841,64 +841,6 @@ export async function runCycle(): Promise<void> {
       }
     }
 
-    // ── Phase 3.6: Sprite Feedback Issue ──
-    // When the Sprite Designer ran and the build is green, post the sprite-feedback
-    // GitHub issue (or comment on an existing one for iterations). Failures are
-    // logged as warnings — we never let issue-creation errors fail the cycle.
-    if (spriteResult && !reverted && finalBuildResult?.success) {
-      if (!spriteResult.metadata) {
-        log.warn(
-          "  ⚠ Phase 3.6: Sprite Designer ran and build succeeded, but no sprite-metadata block was parsed — cannot post feedback issue. Fix the Sprite Designer output or backfill manually.",
-        );
-      } else {
-        const meta = spriteResult.metadata;
-        const imagePaths = spriteResult.filesCreated.filter(
-          (f) => f.includes("graphics/pokemon/") && f.endsWith(".png"),
-        );
-        log.info("Phase 3.6: Posting sprite feedback issue...");
-        try {
-          if (meta.isIteration && meta.existingIssueNumber) {
-            await postSpriteIterationUpdate(
-              meta.existingIssueNumber,
-              spriteResult.spriteReport,
-              imagePaths,
-              meta.version,
-            );
-            log.info(
-              `  Posted sprite iteration v${meta.version} to #${meta.existingIssueNumber}`,
-            );
-          } else {
-            const issueNumber = await createSpriteFeedbackIssue(
-              meta.speciesName,
-              meta.typing,
-              spriteResult.spriteReport,
-              imagePaths,
-              meta.version,
-            );
-            if (issueNumber) {
-              updateSpriteIterationsIssueNumber(
-                meta.speciesName,
-                meta.version,
-                issueNumber,
-              );
-              log.info(
-                `  Created sprite-feedback issue #${issueNumber} for ${meta.speciesName} v${meta.version}`,
-              );
-            } else {
-              log.warn(
-                "  createSpriteFeedbackIssue returned null — issue may not have been created",
-              );
-            }
-          }
-        } catch (err) {
-          const errMsg = err instanceof Error ? err.message : String(err);
-          log.warn(
-            `  Sprite feedback issue creation failed, continuing: ${errMsg}`,
-          );
-        }
-      }
-    }
-
     // ── Phase 4: Reflection (separate agent context) ──
     const reflection = await runReflectionPhase(
       cycleNumber,
@@ -990,6 +932,70 @@ export async function runCycle(): Promise<void> {
     if (commitFailed) {
       log.error("CRITICAL: Cycle completed without producing a git commit.");
       process.exitCode = 1;
+    }
+
+    // ── Phase 3.6 (post-commit): Sprite Feedback Issue ──
+    // Posted after commit so we can use SHA-pinned image URLs that resolve
+    // once the CI push lands. Failures are logged as warnings — we never
+    // let issue-creation errors fail the cycle.
+    if (spriteResult && !reverted && finalBuildResult?.success && commitHash) {
+      if (!spriteResult.metadata) {
+        log.warn(
+          "  ⚠ Phase 3.6: Sprite Designer ran and build succeeded, but no sprite-metadata block was parsed — cannot post feedback issue. Fix the Sprite Designer output or backfill manually.",
+        );
+      } else {
+        const meta = spriteResult.metadata;
+        const imagePaths = spriteResult.filesCreated.filter(
+          (f) => f.includes("graphics/pokemon/") && f.endsWith(".png"),
+        );
+        const repoInfo = getRepoInfo();
+        const repoSlug = repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : undefined;
+        log.info("Phase 3.6: Posting sprite feedback issue...");
+        try {
+          if (meta.isIteration && meta.existingIssueNumber) {
+            await postSpriteIterationUpdate(
+              meta.existingIssueNumber,
+              spriteResult.spriteReport,
+              imagePaths,
+              meta.version,
+              repoSlug,
+              commitHash,
+            );
+            log.info(
+              `  Posted sprite iteration v${meta.version} to #${meta.existingIssueNumber}`,
+            );
+          } else {
+            const issueNumber = await createSpriteFeedbackIssue(
+              meta.speciesName,
+              meta.typing,
+              spriteResult.spriteReport,
+              imagePaths,
+              meta.version,
+              repoSlug,
+              commitHash,
+            );
+            if (issueNumber) {
+              updateSpriteIterationsIssueNumber(
+                meta.speciesName,
+                meta.version,
+                issueNumber,
+              );
+              log.info(
+                `  Created sprite-feedback issue #${issueNumber} for ${meta.speciesName} v${meta.version}`,
+              );
+            } else {
+              log.warn(
+                "  createSpriteFeedbackIssue returned null — issue may not have been created",
+              );
+            }
+          }
+        } catch (err) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          log.warn(
+            `  Sprite feedback issue creation failed, continuing: ${errMsg}`,
+          );
+        }
+      }
     }
 
     // Close accepted issues after successful commit (not reverted).

--- a/src/cycle/sprite-designer.test.ts
+++ b/src/cycle/sprite-designer.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { stripSpriteMetadataBlock, extractSpriteReport, parseSpriteFeedbackMetadata } from "./sprite-designer.js";
+
+describe("stripSpriteMetadataBlock", () => {
+  it("removes the sprite-metadata fenced block", () => {
+    const input = `Some report text\n\n\`\`\`sprite-metadata\n{"speciesName":"Corsola"}\n\`\`\``;
+    expect(stripSpriteMetadataBlock(input)).toBe("Some report text");
+  });
+
+  it("returns the report unchanged when no metadata block exists", () => {
+    const input = "Just a plain report with no metadata";
+    expect(stripSpriteMetadataBlock(input)).toBe(input);
+  });
+
+  it("handles metadata block with extra whitespace after tag", () => {
+    const input = `Report\n\n\`\`\`sprite-metadata  \n{"key":"val"}\n\`\`\`\n`;
+    expect(stripSpriteMetadataBlock(input)).toBe("Report");
+  });
+
+  it("handles multiline JSON in metadata block", () => {
+    const input = `Report\n\n\`\`\`sprite-metadata\n{\n  "speciesName": "Corsola",\n  "typing": "Ghost/Rock"\n}\n\`\`\``;
+    expect(stripSpriteMetadataBlock(input)).toBe("Report");
+  });
+});
+
+describe("extractSpriteReport", () => {
+  it("extracts the Sprite Report section and stops before metadata block", () => {
+    const input = [
+      "Working notes: analysed palette...",
+      "Python output: [0] 200 pixels",
+      "",
+      "## Sprite Report",
+      "",
+      "**Species**: Corsola",
+      "**Version**: v1",
+      "",
+      "```sprite-metadata",
+      '{"speciesName":"Corsola","typing":"Ghost/Rock","version":1,"isIteration":false}',
+      "```",
+    ].join("\n");
+
+    const result = extractSpriteReport(input);
+    expect(result).toContain("## Sprite Report");
+    expect(result).toContain("**Species**: Corsola");
+    expect(result).not.toContain("sprite-metadata");
+    expect(result).not.toContain("Working notes");
+    expect(result).not.toContain("Python output");
+  });
+
+  it("handles ### header variant", () => {
+    const input = "Noise\n\n### Sprite Report\n\nContent here\n\n```sprite-metadata\n{}\n```";
+    const result = extractSpriteReport(input);
+    expect(result).toBe("### Sprite Report\n\nContent here");
+    expect(result).not.toContain("Noise");
+  });
+
+  it("falls back to full text minus metadata when no header found", () => {
+    const input = "No header here, just report text\n\n```sprite-metadata\n{}\n```";
+    const result = extractSpriteReport(input);
+    expect(result).toBe("No header here, just report text");
+    expect(result).not.toContain("sprite-metadata");
+  });
+
+  it("falls back to full text when neither header nor metadata exists", () => {
+    const input = "Plain text report with no structure";
+    expect(extractSpriteReport(input)).toBe(input);
+  });
+
+  it("handles Sprite Report header at the very start", () => {
+    const input = "## Sprite Report\n\nClean report\n\n```sprite-metadata\n{}\n```";
+    const result = extractSpriteReport(input);
+    expect(result).toBe("## Sprite Report\n\nClean report");
+  });
+
+  it("handles Sprite Report header without subsequent metadata block", () => {
+    const input = "Noise\n\n## Sprite Report\n\nClean report without metadata";
+    const result = extractSpriteReport(input);
+    expect(result).toBe("## Sprite Report\n\nClean report without metadata");
+  });
+});
+
+describe("parseSpriteFeedbackMetadata", () => {
+  it("parses valid fresh sprite metadata", () => {
+    const input = 'Report\n\n```sprite-metadata\n{"speciesName":"Corsola","typing":"Ghost/Rock","version":1,"isIteration":false}\n```';
+    const meta = parseSpriteFeedbackMetadata(input);
+    expect(meta).toEqual({
+      speciesName: "Corsola",
+      typing: "Ghost/Rock",
+      version: 1,
+      isIteration: false,
+      existingIssueNumber: undefined,
+    });
+  });
+
+  it("parses valid iteration metadata", () => {
+    const input = '```sprite-metadata\n{"speciesName":"Arcanine","typing":"Water/Fire","version":2,"isIteration":true,"existingIssueNumber":142}\n```';
+    const meta = parseSpriteFeedbackMetadata(input);
+    expect(meta).toEqual({
+      speciesName: "Arcanine",
+      typing: "Water/Fire",
+      version: 2,
+      isIteration: true,
+      existingIssueNumber: 142,
+    });
+  });
+
+  it("returns null when no metadata block exists", () => {
+    expect(parseSpriteFeedbackMetadata("No metadata here")).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    const input = "```sprite-metadata\nnot json\n```";
+    expect(parseSpriteFeedbackMetadata(input)).toBeNull();
+  });
+
+  it("returns null when required fields are missing", () => {
+    const input = '```sprite-metadata\n{"speciesName":"Corsola"}\n```';
+    expect(parseSpriteFeedbackMetadata(input)).toBeNull();
+  });
+
+  it("returns null when isIteration is true but existingIssueNumber missing", () => {
+    const input = '```sprite-metadata\n{"speciesName":"Corsola","typing":"Ghost/Rock","version":2,"isIteration":true}\n```';
+    expect(parseSpriteFeedbackMetadata(input)).toBeNull();
+  });
+});

--- a/src/cycle/sprite-designer.ts
+++ b/src/cycle/sprite-designer.ts
@@ -93,9 +93,9 @@ export async function runSpriteDesigner(
     model: process.env.ANTHROPIC_MODEL,
   });
 
-  const spriteReport = result.narrativeText || result.resultText || "";
+  const rawReport = result.narrativeText || result.resultText || "";
 
-  if (!spriteReport.trim()) {
+  if (!rawReport.trim()) {
     throw new Error("Sprite Designer produced no output");
   }
 
@@ -104,7 +104,9 @@ export async function runSpriteDesigner(
     (f) => f.includes("graphics/pokemon/") || f.endsWith(".py"),
   );
 
-  const metadata = parseSpriteFeedbackMetadata(spriteReport);
+  // Parse metadata from raw report BEFORE stripping, then extract clean report
+  const metadata = parseSpriteFeedbackMetadata(rawReport);
+  const spriteReport = extractSpriteReport(rawReport);
 
   logger.info(
     `[Sprite Designer] Design complete: ${result.toolCallCount} tool calls, ${filesCreated.length} files created/modified`,
@@ -126,6 +128,40 @@ export async function runSpriteDesigner(
     tokenUsage: result.tokenUsage,
     metadata,
   };
+}
+
+/** Regex matching the ```sprite-metadata``` fenced block. */
+const SPRITE_METADATA_BLOCK_RE = /```sprite-metadata\s*\n[\s\S]*?\n```/;
+
+/**
+ * Remove the ```sprite-metadata``` fenced block from a sprite report string.
+ */
+export function stripSpriteMetadataBlock(report: string): string {
+  return report.replace(SPRITE_METADATA_BLOCK_RE, "").trimEnd();
+}
+
+/**
+ * Extract the clean "Sprite Report" section from the full agent narrative.
+ *
+ * The Sprite Designer is instructed to end its output with a "## Sprite Report"
+ * section. This function finds that header and returns content from there up to
+ * the sprite-metadata block (exclusive) or end of text.
+ *
+ * Falls back to stripping just the metadata block when no header is found.
+ */
+export function extractSpriteReport(rawReport: string): string {
+  const headerMatch = rawReport.match(/^(#{1,4}\s+Sprite Report.*)/im);
+  if (!headerMatch) {
+    return stripSpriteMetadataBlock(rawReport);
+  }
+  const headerIndex = rawReport.indexOf(headerMatch[0]);
+  const afterHeader = rawReport.slice(headerIndex);
+
+  const metaBlockIndex = afterHeader.search(/```sprite-metadata\s*\n/);
+  if (metaBlockIndex !== -1) {
+    return afterHeader.slice(0, metaBlockIndex).trimEnd();
+  }
+  return stripSpriteMetadataBlock(afterHeader);
 }
 
 /**

--- a/src/github/issues.ts
+++ b/src/github/issues.ts
@@ -531,6 +531,28 @@ export async function createHelpRequest(
 export const MAX_SPRITE_ITERATIONS = 5;
 
 /**
+ * Format image paths as markdown image links.
+ * When repoSlug and commitSha are provided, uses raw.githubusercontent.com
+ * URLs pinned to the commit (immutable, resolves once pushed). Falls back
+ * to repo-relative paths for local/test scenarios.
+ */
+function formatImageUrls(
+  repoImagePaths: string[],
+  repoSlug?: string,
+  commitSha?: string,
+): string {
+  return repoImagePaths
+    .map((p) => {
+      const name = path.basename(p);
+      if (repoSlug && commitSha) {
+        return `![${name}](https://raw.githubusercontent.com/${repoSlug}/${commitSha}/${p})`;
+      }
+      return `![${name}](/${p})`;
+    })
+    .join("\n");
+}
+
+/**
  * Create a sprite-feedback issue to solicit community feedback on a new
  * or updated regional form sprite.
  * Returns the new issue number, or null on failure.
@@ -541,10 +563,10 @@ export async function createSpriteFeedbackIssue(
   spriteReport: string,
   repoImagePaths: string[],
   version: number,
+  repoSlug?: string,
+  commitSha?: string,
 ): Promise<number | null> {
-  const imageSection = repoImagePaths
-    .map((p) => `![${path.basename(p)}](/${p})`)
-    .join("\n");
+  const imageSection = formatImageUrls(repoImagePaths, repoSlug, commitSha);
   const title = `[Sprite Feedback] Hoenn ${speciesName} (${typing})`;
   const body =
     `🎨 **Agent Oak — Sprite Feedback Request**\n\n` +
@@ -568,10 +590,10 @@ export async function postSpriteIterationUpdate(
   spriteReport: string,
   repoImagePaths: string[],
   version: number,
+  repoSlug?: string,
+  commitSha?: string,
 ): Promise<void> {
-  const imageSection = repoImagePaths
-    .map((p) => `![${path.basename(p)}](/${p})`)
-    .join("\n");
+  const imageSection = formatImageUrls(repoImagePaths, repoSlug, commitSha);
   const body =
     `🎨 **Sprite Update — v${version}**\n\n` +
     `${imageSection}\n\n` +


### PR DESCRIPTION
## Summary
- **Fix broken images**: Move sprite feedback issue posting from Phase 3.6 (before commit) to after Phase 5 (commit), using `raw.githubusercontent.com/{owner}/{repo}/{sha}/...` URLs pinned to the commit SHA instead of repo-relative paths that don't resolve until push
- **Fix metadata leak**: Add `stripSpriteMetadataBlock()` to remove the raw `sprite-metadata` JSON block that was being embedded in the GitHub issue body
- **Fix noisy report**: Add `extractSpriteReport()` to extract only the clean "Sprite Report" section from the agent's full narrative output, filtering out working notes, Python analysis, and other noise

## Test plan
- [x] All 324 existing tests pass
- [x] 16 new unit tests added for `stripSpriteMetadataBlock`, `extractSpriteReport`, and `parseSpriteFeedbackMetadata`
- [ ] Verify sprite feedback issue is posted with working image URLs on next cycle with sprite work

🤖 Generated with [Claude Code](https://claude.com/claude-code)