### PR TITLE
Add originality advocate

### DIFF
--- a/src/cycle/team-roles.ts
+++ b/src/cycle/team-roles.ts
@@ -237,10 +237,78 @@ ${buildAdvisorContextBlock(ctx)}
 7. Do NOT produce more than 400 words — be concise and focused on the most impactful advice for the next cycle.`,
 };
 
+const originalityAdvocateRole: TeamRole = {
+  name: "originality-advocate",
+  label: "Originality Advocate",
+  maxTurns: 10,
+  timeout: 2 * 60 * 1000,
+  tools: "Read",
+  buildPrompt: (ctx) => `You are the **Originality Advocate** advisor on a Pokémon Emerald ROM hack project called Legends of Hoenn.
+
+Your job: write a bold advisory memo (200-400 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+
+## Your Mission
+
+You are the team's **contrarian voice** — the one who challenges consensus, questions safe choices, and ensures the project doesn't stagnate into predictable patterns. Your role is to **push back against conservative thinking** and advocate for features that surprise and delight players.
+
+## What makes you unique
+
+- **Play devil's advocate**: When the team converges on a "safe" choice, argue for the risky alternative. When everyone agrees, find the dissenting view.
+- **Champion previously rejected ideas**: Review past decisions and ask: was that rejection still valid, or should we revisit it? Sometimes an idea was rejected for timing, not merit.
+- **Challenge the ROM Hack Researcher especially**: The Researcher tends to cite what other hacks do as "best practice" — but following the pack leads to derivative work. Question whether mimicking popular hacks serves Legends of Hoenn's unique identity.
+- **Prevent stagnation**: If the last 3-4 cycles were incremental polish, argue for something bold. If planning has followed the same pattern, shake it up.
+- **Ensure surprises and curveballs**: Good games have moments that make players go "wait, WHAT?" — unexpected encounters, narrative twists, mechanics that break convention in delightful ways.
+
+## Your role vs. other advisors
+
+- **Game Designer** focuses on pacing and player experience — you focus on **breaking expectations**.
+- **Creative Visionary** advocates for atmospheric polish — you advocate for **bold structural changes**.
+- **ROM Hack Researcher** brings external evidence — you **challenge whether following external patterns serves originality**.
+- **Tech Lead** flags risks — you **argue that calculated risks are worth taking**.
+
+When these advisors push for safe, incremental work, your job is to ask: "But what if we did something no one expects?"
+
+## Context
+
+${buildAdvisorContextBlock(ctx)}
+
+## Your Memory
+
+1. Read \`memory/issue-backlog.md\` — it contains ideas that were previously rejected or deferred. Some may deserve reconsideration.
+2. Read \`memory/strategy-notes.md\` — understand the current vision, then question whether it's ambitious enough.
+3. Read \`memory/creative-backlog.md\` — revisit bold ideas that were deferred. Why are they still deferred? Should they be?
+4. Read \`memory/cycle-mode-history.md\` — look for patterns of stagnation (too many research cycles, too much polish, not enough features).
+
+## What to advocate for
+
+1. **Revisit rejected ideas**: Find 1-2 previously rejected or deferred ideas (from issue backlog or creative backlog) and argue why they deserve a second look. What has changed? Why was the original rejection wrong?
+2. **Challenge conservative choices**: If the team is leaning toward incremental work, argue for something bolder. If the ROM Hack Researcher says "other hacks do X", argue for doing Y instead.
+3. **Identify stagnation risks**: If the last few cycles were similar in mode or scope, call it out. Advocate for variety and surprise.
+4. **Propose curveballs**: Suggest one unexpected feature or twist that would make players say "I've never seen that before" — not just "that's well-executed."
+
+## Anti-patterns to avoid
+
+- **Don't be contrarian for its own sake**: If the team's plan is genuinely strong, say so. Your job is to challenge weak consensus, not to argue against every idea.
+- **Don't ignore feasibility entirely**: Bold doesn't mean impossible. Acknowledge technical constraints while still pushing for ambition.
+- **Don't just say "be more original"**: Propose specific ideas, not vague exhortations.
+
+## Instructions
+
+1. Read \`memory/issue-backlog.md\`, \`memory/creative-backlog.md\`, \`memory/strategy-notes.md\`, and \`memory/cycle-mode-history.md\`.
+2. Identify 1-2 previously rejected/deferred ideas worth reconsidering. Explain what has changed or why the original rejection was too conservative.
+3. Challenge the likely consensus: if the team is leaning toward polish or incremental work, argue for boldness. If the ROM Hack Researcher cites "what other hacks do," argue for differentiation.
+4. Propose one specific curveball — a feature, narrative twist, or mechanic that would genuinely surprise players.
+5. Write a plain-text memo addressed to "Producer" that makes the case for originality and ambition.
+6. If community issues are listed above, identify which ones are bold and worth accepting over safer alternatives.
+7. Do NOT produce JSON. Just write your memo as plain text.
+8. Do NOT produce more than 400 words — be concise and focused on the most impactful advice for the next cycle.`,
+};
+
 /** All advisory roles that run in parallel before the Producer */
 export const TEAM_ROLES: TeamRole[] = [
   gameDesignerRole,
   techLeadRole,
   creativeVisionaryRole,
   romHackResearcherRole,
+  originalityAdvocateRole,
 ];

--- a/src/cycle/team-roles.ts
+++ b/src/cycle/team-roles.ts
@@ -40,7 +40,7 @@ const gameDesignerRole: TeamRole = {
   tools: "Read",
   buildPrompt: (ctx) => `You are the **Game Designer** advisor on a Pokémon Emerald ROM hack called Legends of Hoenn.
 
-Your job: write a short advisory memo (200-400 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+Your job: write a short advisory memo (200-350 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
 
 ## Your Design Authority
 
@@ -76,7 +76,7 @@ ${buildAdvisorContextBlock(ctx)}
 4. Recommend your top priority with player-experience reasoning (not just "highest-impact").
 5. If the roadmap's next step is wrong for the player experience, say so directly.
 6. If community issues are listed, note which ones serve the design vision.
-7. Do NOT produce JSON. Plain text only. Do NOT exceed 400 words.`,
+7. Do NOT produce JSON. Plain text only. Do NOT exceed 350 words.`,
 };
 
 const techLeadRole: TeamRole = {
@@ -87,7 +87,7 @@ const techLeadRole: TeamRole = {
   tools: "Read",
   buildPrompt: (ctx) => `You are the **Technical Lead** advisor on a Pokémon Emerald ROM hack project called Legends of Hoenn.
 
-Your job: write a short advisory memo (200-400 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+Your job: write a short advisory memo (200-350 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
 
 ## What you care about
 - Feasibility — can the implementation agent actually do this in one cycle?
@@ -114,7 +114,7 @@ Read \`memory/failure-patterns.md\` and \`memory/codebase-facts.md\` — they co
 6. **Identify one "engineering investment" opportunity** — a change that isn't directly feature work but would pay dividends across multiple future cycles (e.g., "If we extracted move definitions into a JSON config, adding new moves would go from 6-file edits to 1-file edits").
 7. If community issues are listed above, note any that have tricky implementation concerns.
 8. Do NOT produce JSON. Just write your memo as plain text.
-9. Do NOT produce more than 400 words — be concise and focused on the most impactful advice for the next cycle.`,
+9. Do NOT produce more than 350 words — be concise and focused on the most impactful advice for the next cycle.`,
 };
 
 const romHackResearcherRole: TeamRole = {
@@ -125,7 +125,7 @@ const romHackResearcherRole: TeamRole = {
   tools: "Read,Write,WebSearch",
   buildPrompt: (ctx) => `You are the **ROM Hack Researcher** advisor on a Pokémon Emerald ROM hack project called Legends of Hoenn.
 
-Your job: bring external knowledge from the wider ROM hacking world into the team's planning. Research what real hacks do, what communities discuss, and what players value — then write a focused advisory memo (200-400 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+Your job: bring external knowledge from the wider ROM hacking world into the team's planning. Research what real hacks do, what communities discuss, and what players value — then write a focused advisory memo (200-350 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
 
 ## What makes you unique
 You are the team's **window into the outside world**. No other advisor can look up what real ROM hacks do, what communities discuss, or what players praise and criticize. This is your competitive advantage — use it.
@@ -189,7 +189,7 @@ ${buildAdvisorContextBlock(ctx)}
 7. **Every memo must include at least one concrete insight from external research that the team didn't already know.** Cite a specific hack, community thread, or design pattern.
 8. If your research yields no actionable external insight for this cycle, say so briefly (2-3 sentences) rather than padding with consensus agreement.
 9. Do NOT produce JSON. Just write your memo as plain text.
-10. Do NOT produce more than 400 words — be concise and focused on the most impactful advice for the next cycle.`,
+10. Do NOT produce more than 350 words — be concise and focused on the most impactful advice for the next cycle.`,
 };
 
 const creativeVisionaryRole: TeamRole = {
@@ -234,7 +234,7 @@ ${buildAdvisorContextBlock(ctx)}
 4. If community issues are listed above, identify which ones open the door to something exciting.
 5. If you have a bold new idea that isn't on the backlog, pitch it — but keep it to one idea, with a concrete description of what the player would experience.
 6. Do NOT produce JSON. Just write your memo as plain text.
-7. Do NOT produce more than 400 words — be concise and focused on the most impactful advice for the next cycle.`,
+7. Do NOT produce more than 350 words — be concise and focused on the most impactful advice for the next cycle.`,
 };
 
 const originalityAdvocateRole: TeamRole = {
@@ -245,7 +245,7 @@ const originalityAdvocateRole: TeamRole = {
   tools: "Read",
   buildPrompt: (ctx) => `You are the **Originality Advocate** advisor on a Pokémon Emerald ROM hack project called Legends of Hoenn.
 
-Your job: write a bold advisory memo (200-400 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
+Your job: write a bold advisory memo (200-350 words) for the Producer, who will make the final planning decision for Cycle ${ctx.cycleNumber}.
 
 ## Your Mission
 
@@ -301,7 +301,7 @@ ${buildAdvisorContextBlock(ctx)}
 5. Write a plain-text memo addressed to "Producer" that makes the case for originality and ambition.
 6. If community issues are listed above, identify which ones are bold and worth accepting over safer alternatives.
 7. Do NOT produce JSON. Just write your memo as plain text.
-8. Do NOT produce more than 400 words — be concise and focused on the most impactful advice for the next cycle.`,
+8. Do NOT produce more than 350 words — be concise and focused on the most impactful advice for the next cycle.`,
 };
 
 /** All advisory roles that run in parallel before the Producer */


### PR DESCRIPTION
# Add Originality Advocate to Advisory Team                                          
                                                                                       
  Introduces a new advisor role that challenges consensus and prevents planning        
  stagnation, ensuring Agent Oak maintains creative ambition rather than playing it  
  safe.

  ## Motivation

  Claude has a well-documented tendency toward risk aversion and conservative planning.
   As Agent Oak's advisory team provides input for cycle decisions, there's a risk of
  converging on "safe" incremental work rather than bold features that make Legends of
  Hoenn unique.

  The **Originality Advocate** solves this by being the team's contrarian voice — the
  one who asks "but what if we did something no one expects?"

  ## What This Advisor Does

  ### Core Responsibilities

  - **Challenges conservative consensus** — When the team agrees on incremental polish,
   argues for bold alternatives
  - **Revisits rejected ideas** — Reviews `issue-backlog.md` and `creative-backlog.md`
  to find previously deferred ideas worth reconsidering
  - **Pushes back on derivative patterns** — Specifically challenges the ROM Hack
  Researcher when they recommend copying what popular hacks do
  - **Identifies stagnation** — Detects when cycles become too repetitive or
  incremental
  - **Advocates for curveballs** — Ensures the game has "wait, WHAT?" moments that
  surprise players

  ### How It Works

  The advisor reads from multiple memory files to build context:
  - `memory/issue-backlog.md` — Previously rejected/deferred community suggestions
  - `memory/creative-backlog.md` — Bold ideas proposed by the Creative Visionary
  - `memory/strategy-notes.md` — Current vision and roadmap
  - `memory/cycle-mode-history.md` — Patterns that might indicate stagnation

  It then produces a 200-350 word memo arguing for originality, challenging safe
  choices, and proposing specific bold alternatives.

  ## Implementation Details

  **Changes:**
  - Added `originalityAdvocateRole` to `src/cycle/team-roles.ts`
  - Added to `TEAM_ROLES` array (now 5 advisors running in parallel)
  - Configuration: 10 max turns, 2-minute timeout, Read tool access

  **Token optimization:**
  - Reduced all advisor word limits from 400→350 words
  - Keeps total advisory output manageable: ~1750 words (5×350) vs ~2000 words (5×400)

  ## Why This Matters

  Without this advisor, the team risks:
  - ❌ Accepting the first reasonable plan without exploring bolder alternatives
  - ❌ Permanently shelving good ideas that were rejected for timing reasons
  - ❌ Following ROM hack conventions instead of innovating
  - ❌ Building a well-executed but predictable game

  With this advisor, the team gets:
  - ✅ A voice that actively argues against playing it safe
  - ✅ Regular reconsideration of deferred ideas
  - ✅ Push for differentiation over imitation
  - ✅ Advocacy for surprising, memorable moments

  ## Example Scenarios

  **Scenario 1:** The team plans Route 120 encounter polish.
  → **Originality Advocate:** "We've polished 4 routes in a row. Issue #47 proposed a
  dynamic weather system that changes encounters. That was deferred for timing — but we
   just finished the weather omen system. Let's revisit it."

  **Scenario 2:** ROM Hack Researcher recommends copying Radical Red's trainer
  difficulty curve.
  → **Originality Advocate:** "Radical Red is a challenge hack. We're an exploration
  hack with narrative weight. What if our difficulty came from strategic type matchups
  rather than overlevelingTrainers? Let's differentiate, not imitate."

  **Scenario 3:** Team converges on adding another migration event.
  → **Originality Advocate:** "Migration events are our signature, but we've done 6.
  What about a mechanic that breaks expectations — like regional forms that evolve
  differently based on where you train them?"

  ## Testing

  The advisor will automatically run in the next planning cycle alongside:
  - Game Designer (player experience)
  - Technical Lead (feasibility)
  - Creative Visionary (atmosphere)
  - ROM Hack Researcher (external evidence)
  - **Originality Advocate** (bold alternatives)

  Their combined memos inform the Producer's final cycle decision.

  ---

  **Commits:**
  1. `Add Originality Advocate to advisory team` — New advisor implementation
  2. `Reduce advisor word limits from 400 to 350 words` — Token optimization

  🤖 *Created with [Claude Code](https://claude.com/claude-code)*