### PR TITLE
Bump personality values into the active 'high' bucket

### DIFF
--- a/personality.json
+++ b/personality.json
@@ -1,5 +1,5 @@
 {
-  "riskTolerance": 60,
-  "communityOpenness": 55,
-  "ambitionLevel": 45
+  "riskTolerance": 70,
+  "communityOpenness": 75,
+  "ambitionLevel": 70
 }


### PR DESCRIPTION
## Summary

All three personality traits (`riskTolerance`, `communityOpenness`, `ambitionLevel`) are currently in the "moderate" bucket (≤60). Due to the early-return on line 169 of `personality.ts`:

```typescript
if (risk === "moderate" && community === "moderate" && ambition === "moderate") {
  return "";
}
```

...the personality system is injecting **zero guidance** into Oak's planner prompt. The feature you built to tune Oak's behavior is currently a no-op.

This PR bumps the values into the "high" bucket (>60) so the guidance actually fires:

| Trait | Before | After | Bucket change |
|---|---|---|---|
| `riskTolerance` | 60 | 70 | moderate → **high** |
| `communityOpenness` | 55 | 75 | moderate → **high** |
| `ambitionLevel` | 45 | 70 | moderate → **high** |

### What Oak will actually receive in its planner prompt after this change

- **Risk**: "Prefer ambitious changes that touch multiple systems over safe single-file patches. When the Tech Lead flags complexity or risk, acknowledge it but don't let it default you to the conservative option."
- **Community**: "Default to accepting community suggestions unless they clearly conflict with the project vision. Give contributors the benefit of the doubt — if a suggestion is partially aligned, accept the aligned parts rather than deferring the whole thing."
- **Ambition**: "A cycle that transforms an entire game system is more valuable than one that tweaks a single value. When the Creative Visionary proposes something bold, lean into it."

Previously Oak received **none of this** — it was operating on pure defaults with no personality nudge at all.

### Why these specific values

- Not maxed out — `very-high` (>80) guidance gets reckless ("safe patches are a last resort", "The Tech Lead's risk warnings should rarely override"). The "high" bucket is the sweet spot: ambitious but not unhinged.
- `communityOpenness` gets the biggest bump (55→75) because the current deferral patterns are the most visible problem. Issues #151 and #152 have been deferred 5 times. #159 was rejected with a sunk-cost argument.
- Easy to revert or tune further. If Oak gets too aggressive, dial one value back to 60 and it drops to moderate (silent) for that trait.

### Related

- PR #129 (Originality Advocate role) — addresses the same problem from the advisor side
- Issues #172, #173, #174 — community feedback audit documenting the conservative patterns this aims to fix

This is a one-line config change. You'd have data on whether it works within 3-4 cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)